### PR TITLE
Updated MANUAL_ACCOUNT_CREATION to CREATE_MANAGE_DRAFT_ACCOUNTS

### DIFF
--- a/cypress/e2e/functional/opal/manualAccountCreation/welshLanguages/PO-465_languagePreferencesOnAccountDetails.feature
+++ b/cypress/e2e/functional/opal/manualAccountCreation/welshLanguages/PO-465_languagePreferencesOnAccountDetails.feature
@@ -33,7 +33,7 @@ Feature: PO-465 language preferences page for all defendant types
       | Company                                       |
 
   Scenario Outline:AC1,2,3,4 Language preferences for All defendants - negative test
-    When I sign in as "opal-test-10@HMCTS.NET"
+    When I sign in as "opal-test@HMCTS.NET"
     Then I am on the dashboard
     When I navigate to Manual Account Creation
 

--- a/src/app/flows/fines/fines-mac/fines-mac-create-account/fines-mac-create-account.component.ts
+++ b/src/app/flows/fines/fines-mac/fines-mac-create-account/fines-mac-create-account.component.ts
@@ -34,7 +34,7 @@ export class FinesMacCreateAccountComponent extends AbstractFormParentBaseCompon
   private businessUnits!: IOpalFinesBusinessUnit[];
   private configurationItems = FINES_MAC_CREATE_ACCOUNT_CONFIGURATION_ITEMS;
   public data$: Observable<IGovUkSelectOptions[]> = this.opalFinesService
-    .getBusinessUnits('MANUAL_ACCOUNT_CREATION')
+    .getBusinessUnits('CREATE_MANAGE_DRAFT_ACCOUNTS')
     .pipe(
       tap((response: IOpalFinesBusinessUnitRefData) => this.setBusinessUnit(response)),
       map((response: IOpalFinesBusinessUnitRefData) => {

--- a/src/app/flows/fines/services/opal-fines-service/opal-fines.service.ts
+++ b/src/app/flows/fines/services/opal-fines-service/opal-fines.service.ts
@@ -121,7 +121,7 @@ export class OpalFines {
   public getBusinessUnits(permission: string) {
     // Business units are cached to prevent multiple requests for the same data.
     // We can have multiple permission types so we need to cache them separately.
-    // e.g. ACCOUNT_ENQUIRY, ACCOUNT_ENQUIRY_NOTES, MANUAL_ACCOUNT_CREATION
+    // e.g. ACCOUNT_ENQUIRY, ACCOUNT_ENQUIRY_NOTES, CREATE_MANAGE_DRAFT_ACCOUNTS
     if (!this.businessUnitsCache$[permission]) {
       this.businessUnitsCache$[permission] = this.http
         .get<IOpalFinesBusinessUnitRefData>(OPAL_FINES_PATHS.businessUnitRefData, { params: { permission } })


### PR DESCRIPTION
### Jira link
N/A

### Change description
- [PR-547](https://github.com/hmcts/opal-fines-service/pull/547)
- Incorporate the changes in the database and backend to the permission
- MANUAL_ACCOUNT_CREATION is now CREATE_MANAGE_DRAFT_ACCOUNTS

### Testing done
- Tested locally and seems to be working after grabbing latest of the BE

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
