### PR TITLE
fix: Exclude mock files from SonarCloud

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.projectName=opal-frontend
 sonar.projectVersion=0.0.1
 
 sonar.sources=src/
-sonar.exclusions=src/main.ts,src/main.server.ts,src/app/app.config.ts,src/app/app.config.server.ts,src/**/*.routes.ts
+sonar.exclusions=src/main.ts,src/main.server.ts,src/app/app.config.ts,src/app/app.config.server.ts,src/**/*.routes.ts,src/**/*.mock.ts
 sonar.test.inclusions=src/**/*.spec.ts
 
 sonar.javascript.lcov.reportPaths=coverage/**/lcov.info


### PR DESCRIPTION
Exclude mock files from SonarCloud as they don't need to be linted.