### PR TITLE
refactor(session): move sessionStorageConfig definition into configureSession function. Add temp console.log

### DIFF
--- a/server-setup.ts
+++ b/server-setup.ts
@@ -16,17 +16,6 @@ import {
 const env = process.env['NODE_ENV'] || 'development';
 const developmentMode = env === 'development';
 
-const sessionStorageConfig: SessionStorageConfiguration = {
-  secret: config.get('secrets.opal.opal-frontend-cookie-secret'),
-  prefix: config.get('session.prefix'),
-  maxAge: config.get('session.maxAge'),
-  sameSite: config.get('session.sameSite'),
-  secure: config.get('session.secure'),
-  domain: config.get('session.domain'),
-  redisEnabled: config.get('features.redis.enabled'),
-  redisConnectionString: config.get('secrets.opal.redis-connection-string'),
-};
-
 export function getRoutesConfig(): {
   sessionExpiryConfiguration: ExpiryConfiguration;
   routesConfiguration: RoutesConfiguration;
@@ -57,6 +46,19 @@ export function configureApiProxyRoutes(app: express.Express): void {
 }
 
 export function configureSession(server: express.Express): void {
+  const sessionStorageConfig: SessionStorageConfiguration = {
+    secret: config.get('secrets.opal.opal-frontend-cookie-secret'),
+    prefix: config.get('session.prefix'),
+    maxAge: config.get('session.maxAge'),
+    sameSite: config.get('session.sameSite'),
+    secure: config.get('session.secure'),
+    domain: config.get('session.domain'),
+    redisEnabled: config.get('features.redis.enabled'),
+    redisConnectionString: config.get('secrets.opal.redis-connection-string'),
+  };
+
+  console.log('[DEBUG] Redis connection string length:', sessionStorageConfig.redisConnectionString.length);
+
   new SessionStorage().enableFor(server, sessionStorageConfig);
 }
 


### PR DESCRIPTION
### Jira link

### Change description
- Move sessionStorageConfig into the method rather that declaring at the top of the server-config.ts
- Add temp console.log to test length of redis connection string

### Testing done

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
