### PR TITLE
PO-618

### DIFF
--- a/src/app/flows/fines/fines-draft/constants/fines-draft-max-rejected.constant.ts
+++ b/src/app/flows/fines/fines-draft/constants/fines-draft-max-rejected.constant.ts
@@ -1,0 +1,1 @@
+export const FINES_DRAFT_MAX_REJECTED = 99;

--- a/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/fines-draft-check-and-manage-tabs/fines-draft-check-and-manage-tabs.component.html
+++ b/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/fines-draft-check-and-manage-tabs/fines-draft-check-and-manage-tabs.component.html
@@ -11,25 +11,18 @@
       subNavItemText="In review"
     ></opal-lib-moj-sub-navigation-item>
     @if (rejectedCount$ | async; as rejectedCount) {
-      @if (rejectedCount === '0') {
-        <opal-lib-moj-sub-navigation-item
-          subNavItemId="inputter-rejected-tab"
-          [activeSubNavItemFragment]="activeTab"
-          subNavItemFragment="rejected"
-          subNavItemText="Rejected"
-        ></opal-lib-moj-sub-navigation-item>
-      } @else {
-        <opal-lib-moj-sub-navigation-item
-          subNavItemId="inputter-rejected-tab"
-          [activeSubNavItemFragment]="activeTab"
-          subNavItemFragment="rejected"
-          subNavItemText="Rejected"
-        >
-          <opal-lib-moj-badge badge badgeId="inputter-rejected-tab-rejected-count">{{
-            rejectedCount
-          }}</opal-lib-moj-badge>
-        </opal-lib-moj-sub-navigation-item>
-      }
+      <opal-lib-moj-sub-navigation-item
+        subNavItemId="inputter-rejected-tab"
+        [activeSubNavItemFragment]="activeTab"
+        subNavItemFragment="rejected"
+        subNavItemText="Rejected"
+      >
+        @if (rejectedCount !== '0') {
+          <opal-lib-moj-badge badge badgeId="inputter-rejected-tab-rejected-count">
+            {{ rejectedCount }}
+          </opal-lib-moj-badge>
+        }
+      </opal-lib-moj-sub-navigation-item>
     }
     <opal-lib-moj-sub-navigation-item
       subNavItemId="inputter-approved-tab"
@@ -64,7 +57,7 @@
   }
 
   <ng-template #tableWrapper>
-    @if (draftAccounts$ | async; as draftAccounts) {
+    @if (tabData$ | async; as draftAccounts) {
       @if (draftAccounts.length) {
         @if (activeTab === 'rejected') {
           <ng-container *ngTemplateOutlet="rejectedTeamMemberData"></ng-container>

--- a/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/fines-draft-check-and-manage-tabs/fines-draft-check-and-manage-tabs.component.ts
+++ b/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/fines-draft-check-and-manage-tabs/fines-draft-check-and-manage-tabs.component.ts
@@ -199,9 +199,8 @@ export class FinesDraftCheckAndManageTabsComponent implements OnInit, OnDestroy 
           const capped = this.formatCount(resolverRejectedCount);
           return of(capped);
         } else {
-          // Fetch new rejected count on tab change
           const params = {
-            businessUnitIds: [], // Provide actual business unit IDs here if needed
+            businessUnitIds: this.businessUnitIds,
             statuses: [OpalFinesDraftAccountStatuses.rejected],
           };
           return this.opalFinesService.getDraftAccounts(params).pipe(map((res) => this.formatCount(res.count)));

--- a/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/fines-draft-view-all-rejected/fines-draft-view-all-rejected.component.html
+++ b/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/fines-draft-view-all-rejected/fines-draft-view-all-rejected.component.html
@@ -1,2 +1,14 @@
-<opal-lib-govuk-back-link (clickEvent)="navigateBack()"></opal-lib-govuk-back-link>
-<h1 class="govuk-heading-l">All rejected accounts</h1>
+<div class="govuk-grid-column-full">
+  <opal-lib-govuk-back-link (clickEvent)="navigateBack()"></opal-lib-govuk-back-link>
+  <h1 class="govuk-heading-l">All rejected accounts</h1>
+  @if (rejectedAccounts.length > 0) {
+    <app-fines-draft-table-wrapper
+      [tableData]="rejectedAccounts"
+      [existingSortState]="tableSort"
+      [isApprovedTab]="false"
+      (linkClicked)="onDefendantClick($event)"
+    ></app-fines-draft-table-wrapper>
+  } @else {
+    <p>There are no rejected accounts.</p>
+  }
+</div>

--- a/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/fines-draft-view-all-rejected/fines-draft-view-all-rejected.component.spec.ts
+++ b/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/fines-draft-view-all-rejected/fines-draft-view-all-rejected.component.spec.ts
@@ -5,24 +5,41 @@ import { GovukBackLinkComponent } from '@hmcts/opal-frontend-common/components/g
 import { FinesDraftStoreType } from '../../stores/types/fines-draft.type';
 import { FinesDraftStore } from '../../stores/fines-draft.store';
 import { FINES_DRAFT_CHECK_AND_MANAGE_ROUTING_PATHS } from '../routing/constants/fines-draft-check-and-manage-routing-paths.constant';
+import { OPAL_FINES_DRAFT_ACCOUNTS_MOCK } from '@services/fines/opal-fines-service/mocks/opal-fines-draft-accounts.mock';
+import { FinesDraftService } from '../../services/fines-draft.service';
+import { FINES_DRAFT_TABLE_WRAPPER_TABLE_DATA_MOCK } from '../../fines-draft-table-wrapper/mocks/fines-draft-table-wrapper-table-data.mock';
 
 describe('FinesDraftViewAllRejectedComponent', () => {
   let component: FinesDraftViewAllRejectedComponent;
   let fixture: ComponentFixture<FinesDraftViewAllRejectedComponent>;
   let mockRouter: jasmine.SpyObj<Router>;
   let finesDraftStore: FinesDraftStoreType;
+  let finesDraftService: jasmine.SpyObj<FinesDraftService>;
 
   beforeEach(async () => {
     mockRouter = jasmine.createSpyObj('Router', ['navigate']);
+
+    finesDraftService = jasmine.createSpyObj<FinesDraftService>('FinesDraftService', [
+      'onDefendantClick',
+      'populateTableData',
+    ]);
+    finesDraftService.populateTableData.and.returnValue(FINES_DRAFT_TABLE_WRAPPER_TABLE_DATA_MOCK);
 
     await TestBed.configureTestingModule({
       imports: [FinesDraftViewAllRejectedComponent, GovukBackLinkComponent],
       providers: [
         { provide: Router, useValue: mockRouter },
+        { provide: FinesDraftService, useValue: finesDraftService },
         {
           provide: ActivatedRoute,
           useValue: {
-            parent: { snapshot: { url: ['check-and-manage'] } },
+            snapshot: {
+              url: ['check-and-manage'],
+              data: {
+                allRejectedAccounts: OPAL_FINES_DRAFT_ACCOUNTS_MOCK,
+              },
+              fragment: 'rejected',
+            },
           },
         },
       ],
@@ -48,5 +65,12 @@ describe('FinesDraftViewAllRejectedComponent', () => {
       relativeTo: component['activatedRoute'].parent,
       fragment: finesDraftStore.fragment(),
     });
+  });
+
+  it('should call viewAllAccounts and amend then call onDefendantClick with PATH_REVIEW_ACCOUNT', () => {
+    component.onDefendantClick(123);
+    expect(finesDraftStore.viewAllAccounts()).toBeTruthy();
+    expect(finesDraftStore.amend()).toBeFalsy();
+    expect(finesDraftService.onDefendantClick).toHaveBeenCalledWith(123, component.PATH_REVIEW_ACCOUNT);
   });
 });

--- a/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/fines-draft-view-all-rejected/fines-draft-view-all-rejected.component.ts
+++ b/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/fines-draft-view-all-rejected/fines-draft-view-all-rejected.component.ts
@@ -1,20 +1,40 @@
-import { Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { GovukBackLinkComponent } from '@hmcts/opal-frontend-common/components/govuk/govuk-back-link';
 import { FinesDraftStore } from '../../stores/fines-draft.store';
 import { FINES_DRAFT_CHECK_AND_MANAGE_ROUTING_PATHS } from '../routing/constants/fines-draft-check-and-manage-routing-paths.constant';
+import { FinesDraftTableWrapperComponent } from '../../fines-draft-table-wrapper/fines-draft-table-wrapper.component';
+import { FINES_DRAFT_TABLE_WRAPPER_SORT_DEFAULT } from '../../fines-draft-table-wrapper/constants/fines-draft-table-wrapper-table-sort-default.constant';
+import { IOpalFinesDraftAccountsResponse } from '@services/fines/opal-fines-service/interfaces/opal-fines-draft-account-data.interface';
+import { IFinesDraftTableWrapperTableData } from '../../fines-draft-table-wrapper/interfaces/fines-draft-table-wrapper-table-data.interface';
+import { FinesDraftService } from '../../services/fines-draft.service';
+import { FINES_ROUTING_PATHS } from '@routing/fines/constants/fines-routing-paths.constant';
+import { FINES_MAC_ROUTING_PATHS } from '../../../fines-mac/routing/constants/fines-mac-routing-paths.constant';
 
 @Component({
   selector: 'app-fines-draft-view-all-rejected',
   standalone: true,
-  imports: [GovukBackLinkComponent],
+  imports: [GovukBackLinkComponent, FinesDraftTableWrapperComponent],
   templateUrl: './fines-draft-view-all-rejected.component.html',
-  styles: ``,
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class FinesDraftViewAllRejectedComponent {
+export class FinesDraftViewAllRejectedComponent implements OnInit {
   private readonly router = inject(Router);
   private readonly activatedRoute = inject(ActivatedRoute);
   private readonly finesDraftStore = inject(FinesDraftStore);
+  public readonly finesDraftService = inject(FinesDraftService);
+
+  public tableSort = FINES_DRAFT_TABLE_WRAPPER_SORT_DEFAULT;
+  public rejectedAccounts!: IFinesDraftTableWrapperTableData[];
+
+  public readonly PATH_REVIEW_ACCOUNT = `${FINES_ROUTING_PATHS.root}/${FINES_MAC_ROUTING_PATHS.root}/${FINES_MAC_ROUTING_PATHS.children.reviewAccount}`;
+
+  public onDefendantClick(draftAccountId: number): void {
+    this.finesDraftStore.setViewAllAccounts(true);
+    this.finesDraftStore.setAmend(false);
+
+    this.finesDraftService.onDefendantClick(draftAccountId, this.PATH_REVIEW_ACCOUNT);
+  }
 
   /**
    * Navigates back to the inputter route within the fines draft routing paths.
@@ -27,5 +47,14 @@ export class FinesDraftViewAllRejectedComponent {
       relativeTo: this.activatedRoute.parent,
       fragment: this.finesDraftStore.fragment(),
     });
+  }
+
+  public ngOnInit(): void {
+    const allRejectedAccounts = this.activatedRoute.snapshot.data[
+      'allRejectedAccounts'
+    ] as IOpalFinesDraftAccountsResponse;
+
+    this.rejectedAccounts = this.finesDraftService['populateTableData'](allRejectedAccounts);
+    this.finesDraftStore.setViewAllAccounts(false);
   }
 }

--- a/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/routing/fines-draft-check-and-manage.routes.ts
+++ b/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/routing/fines-draft-check-and-manage.routes.ts
@@ -7,6 +7,8 @@ import { IFinesDraftCheckAndManageRoutingPermissions } from './interfaces/fines-
 import { FINES_DRAFT_CHECK_AND_MANAGE_ROUTING_PERMISSIONS } from './constants/fines-draft-check-and-manage-routing-permissions.constant';
 import { FINES_DRAFT_CHECK_AND_MANAGE_ROUTING_PATHS } from './constants/fines-draft-check-and-manage-routing-paths.constant';
 import { FINES_DRAFT_CHECK_AND_MANAGE_ROUTING_TITLES } from './constants/fines-draft-check-and-manage-routing-titles.constant';
+import { finesDraftCheckAndManageTabResolver } from './resolvers/fines-draft-check-and-manage-tab.resolver';
+import { finesDraftCheckAndManageRejectedCountResolver } from './resolvers/fines-draft-check-and-manage-rejected-count.resolver';
 
 const draftCreateAndManageRootPath = FINES_DRAFT_ROUTING_PATHS.children.createAndManage;
 const draftCreateAndManagePermissionId =
@@ -31,7 +33,11 @@ export const routing: Routes = [
       routePermissionId: [draftCreateAndManagePermissionId],
       title: FINES_DRAFT_CHECK_AND_MANAGE_ROUTING_TITLES.children.tabs,
     },
-    resolve: { title: TitleResolver },
+    resolve: {
+      title: TitleResolver,
+      draftAccounts: finesDraftCheckAndManageTabResolver,
+      rejectedCount: finesDraftCheckAndManageRejectedCountResolver,
+    },
   },
   {
     path: FINES_DRAFT_CHECK_AND_MANAGE_ROUTING_PATHS.children.viewAllRejected,

--- a/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/routing/fines-draft-check-and-manage.routes.ts
+++ b/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/routing/fines-draft-check-and-manage.routes.ts
@@ -9,6 +9,7 @@ import { FINES_DRAFT_CHECK_AND_MANAGE_ROUTING_PATHS } from './constants/fines-dr
 import { FINES_DRAFT_CHECK_AND_MANAGE_ROUTING_TITLES } from './constants/fines-draft-check-and-manage-routing-titles.constant';
 import { finesDraftCheckAndManageTabResolver } from './resolvers/fines-draft-check-and-manage-tab.resolver';
 import { finesDraftCheckAndManageRejectedCountResolver } from './resolvers/fines-draft-check-and-manage-rejected-count.resolver';
+import { finesDraftCheckAndManageViewAllRejectedResolver } from './resolvers/fines-draft-check-and-manage-view-all-rejected.resolver';
 
 const draftCreateAndManageRootPath = FINES_DRAFT_ROUTING_PATHS.children.createAndManage;
 const draftCreateAndManagePermissionId =
@@ -50,6 +51,9 @@ export const routing: Routes = [
       routePermissionId: [draftCreateAndManagePermissionId],
       title: FINES_DRAFT_CHECK_AND_MANAGE_ROUTING_TITLES.children.viewAllRejected,
     },
-    resolve: { title: TitleResolver },
+    resolve: {
+      title: TitleResolver,
+      allRejectedAccounts: finesDraftCheckAndManageViewAllRejectedResolver,
+    },
   },
 ];

--- a/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/routing/resolvers/fines-draft-check-and-manage-rejected-count.resolver.spec.ts
+++ b/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/routing/resolvers/fines-draft-check-and-manage-rejected-count.resolver.spec.ts
@@ -40,6 +40,7 @@ describe('finesDraftCheckAndManageRejectedCountResolver', () => {
 
     expect(opalFinesServiceMock.getDraftAccounts).toHaveBeenCalledWith({
       businessUnitIds: SESSION_USER_STATE_MOCK.business_unit_user.map((u) => u.business_unit_id),
+      submittedBy: SESSION_USER_STATE_MOCK.business_unit_user.map((u) => u.business_unit_user_id),
       statuses: [OpalFinesDraftAccountStatuses.rejected],
     });
   });

--- a/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/routing/resolvers/fines-draft-check-and-manage-rejected-count.resolver.spec.ts
+++ b/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/routing/resolvers/fines-draft-check-and-manage-rejected-count.resolver.spec.ts
@@ -1,0 +1,46 @@
+import { TestBed } from '@angular/core/testing';
+import { lastValueFrom, Observable, of } from 'rxjs';
+import { finesDraftCheckAndManageRejectedCountResolver } from './fines-draft-check-and-manage-rejected-count.resolver';
+import { OpalFines } from '@services/fines/opal-fines-service/opal-fines.service';
+import { GlobalStore } from '@hmcts/opal-frontend-common/stores/global';
+import { GlobalStoreType } from '@hmcts/opal-frontend-common/stores/global/types';
+import { SESSION_USER_STATE_MOCK } from '@hmcts/opal-frontend-common/services/session-service/mocks';
+import { OPAL_FINES_DRAFT_ACCOUNTS_MOCK } from '@services/fines/opal-fines-service/mocks/opal-fines-draft-accounts.mock';
+import { ActivatedRouteSnapshot, RedirectCommand, ResolveFn, RouterStateSnapshot } from '@angular/router';
+import { OpalFinesDraftAccountStatuses } from '@services/fines/opal-fines-service/enums/opal-fines-draft-account-statuses.enum';
+
+describe('finesDraftCheckAndManageRejectedCountResolver', () => {
+  const executeResolver: ResolveFn<number> = (...resolverParameters) =>
+    TestBed.runInInjectionContext(() => finesDraftCheckAndManageRejectedCountResolver(...resolverParameters));
+
+  let opalFinesServiceMock: jasmine.SpyObj<OpalFines>;
+  let globalStoreMock: GlobalStoreType;
+
+  beforeEach(() => {
+    opalFinesServiceMock = jasmine.createSpyObj('OpalFines', ['getDraftAccounts']);
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: OpalFines, useValue: opalFinesServiceMock }],
+    });
+
+    globalStoreMock = TestBed.inject(GlobalStore);
+    globalStoreMock.setUserState(SESSION_USER_STATE_MOCK);
+  });
+
+  it('should resolve the count of rejected draft accounts', async () => {
+    opalFinesServiceMock.getDraftAccounts.and.returnValue(of(structuredClone(OPAL_FINES_DRAFT_ACCOUNTS_MOCK)));
+
+    const route = {} as ActivatedRouteSnapshot;
+    const mockRouterStateSnapshot = {} as jasmine.SpyObj<RouterStateSnapshot>;
+
+    const result = await lastValueFrom(
+      executeResolver(route, mockRouterStateSnapshot) as Observable<number | RedirectCommand>,
+    );
+    expect(result).toEqual(OPAL_FINES_DRAFT_ACCOUNTS_MOCK.count);
+
+    expect(opalFinesServiceMock.getDraftAccounts).toHaveBeenCalledWith({
+      businessUnitIds: SESSION_USER_STATE_MOCK.business_unit_user.map((u) => u.business_unit_id),
+      statuses: [OpalFinesDraftAccountStatuses.rejected],
+    });
+  });
+});

--- a/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/routing/resolvers/fines-draft-check-and-manage-rejected-count.resolver.ts
+++ b/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/routing/resolvers/fines-draft-check-and-manage-rejected-count.resolver.ts
@@ -11,9 +11,11 @@ export const finesDraftCheckAndManageRejectedCountResolver: ResolveFn<number> = 
 
   const userState = globalStore.userState();
   const businessUnitIds = userState.business_unit_user.map((u) => u.business_unit_id);
+  const businessUnitUserIds = userState.business_unit_user.map((u) => u.business_unit_user_id);
 
   const params = {
     businessUnitIds,
+    submittedBy: businessUnitUserIds,
     statuses: [OpalFinesDraftAccountStatuses.rejected],
   };
 

--- a/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/routing/resolvers/fines-draft-check-and-manage-rejected-count.resolver.ts
+++ b/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/routing/resolvers/fines-draft-check-and-manage-rejected-count.resolver.ts
@@ -1,0 +1,21 @@
+import { inject } from '@angular/core';
+import { ResolveFn } from '@angular/router';
+import { map } from 'rxjs';
+import { OpalFines } from '@services/fines/opal-fines-service/opal-fines.service';
+import { OpalFinesDraftAccountStatuses } from '@services/fines/opal-fines-service/enums/opal-fines-draft-account-statuses.enum';
+import { GlobalStore } from '@hmcts/opal-frontend-common/stores/global';
+
+export const finesDraftCheckAndManageRejectedCountResolver: ResolveFn<number> = () => {
+  const opalFinesService = inject(OpalFines);
+  const globalStore = inject(GlobalStore);
+
+  const userState = globalStore.userState();
+  const businessUnitIds = userState.business_unit_user.map((u) => u.business_unit_id);
+
+  const params = {
+    businessUnitIds,
+    statuses: [OpalFinesDraftAccountStatuses.rejected],
+  };
+
+  return opalFinesService.getDraftAccounts(params).pipe(map((res) => res.count));
+};

--- a/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/routing/resolvers/fines-draft-check-and-manage-tab.resolver.spec.ts
+++ b/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/routing/resolvers/fines-draft-check-and-manage-tab.resolver.spec.ts
@@ -10,6 +10,7 @@ import { FINES_DRAFT_TAB_STATUSES } from '../../../constants/fines-draft-tab-sta
 import { GlobalStoreType } from '@hmcts/opal-frontend-common/stores/global/types';
 
 describe('finesDraftCheckAndManageTabResolver', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const executeResolver: ResolveFn<any> = (...resolverParameters) =>
     TestBed.runInInjectionContext(() => finesDraftCheckAndManageTabResolver(...resolverParameters));
 

--- a/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/routing/resolvers/fines-draft-check-and-manage-tab.resolver.spec.ts
+++ b/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/routing/resolvers/fines-draft-check-and-manage-tab.resolver.spec.ts
@@ -1,0 +1,69 @@
+import { TestBed } from '@angular/core/testing';
+import { lastValueFrom, Observable, of } from 'rxjs';
+import { finesDraftCheckAndManageTabResolver } from './fines-draft-check-and-manage-tab.resolver';
+import { OpalFines } from '@services/fines/opal-fines-service/opal-fines.service';
+import { GlobalStore } from '@hmcts/opal-frontend-common/stores/global';
+import { SESSION_USER_STATE_MOCK } from '@hmcts/opal-frontend-common/services/session-service/mocks';
+import { OPAL_FINES_DRAFT_ACCOUNTS_MOCK } from '@services/fines/opal-fines-service/mocks/opal-fines-draft-accounts.mock';
+import { ActivatedRouteSnapshot, ResolveFn } from '@angular/router';
+import { FINES_DRAFT_TAB_STATUSES } from '../../../constants/fines-draft-tab-statuses.constant';
+import { GlobalStoreType } from '@hmcts/opal-frontend-common/stores/global/types';
+
+describe('finesDraftCheckAndManageTabResolver', () => {
+  const executeResolver: ResolveFn<any> = (...resolverParameters) =>
+    TestBed.runInInjectionContext(() => finesDraftCheckAndManageTabResolver(...resolverParameters));
+
+  let opalFinesServiceMock: jasmine.SpyObj<OpalFines>;
+  let globalStoreMock: GlobalStoreType;
+
+  beforeEach(() => {
+    opalFinesServiceMock = jasmine.createSpyObj('OpalFines', ['getDraftAccounts']);
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: OpalFines, useValue: opalFinesServiceMock }, GlobalStore],
+    });
+
+    globalStoreMock = TestBed.inject(GlobalStore);
+    globalStoreMock.setUserState(SESSION_USER_STATE_MOCK);
+  });
+
+  it('should call opalFinesService.getDraftAccounts with correct params and return observable result', async () => {
+    opalFinesServiceMock.getDraftAccounts.and.returnValue(of(structuredClone(OPAL_FINES_DRAFT_ACCOUNTS_MOCK)));
+
+    const tab = FINES_DRAFT_TAB_STATUSES[0];
+    const fragment = tab.tab;
+    const statuses = tab.statuses;
+    const mockRoute = { fragment } as ActivatedRouteSnapshot;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await lastValueFrom(executeResolver(mockRoute, {} as any) as Observable<any>);
+
+    expect(opalFinesServiceMock.getDraftAccounts).toHaveBeenCalledWith({
+      businessUnitIds: SESSION_USER_STATE_MOCK.business_unit_user.map((u) => u.business_unit_id),
+      statuses,
+      submittedBy: SESSION_USER_STATE_MOCK.business_unit_user.map((u) => u.business_unit_user_id),
+    });
+    expect(result).toEqual(OPAL_FINES_DRAFT_ACCOUNTS_MOCK);
+  });
+
+  it('should return { count: 0, summaries: [] } when statuses is null (fragment not found)', async () => {
+    const invalidFragment = 'non-existent-fragment';
+    const mockRoute = { fragment: invalidFragment } as ActivatedRouteSnapshot;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await lastValueFrom(executeResolver(mockRoute, {} as any) as Observable<any>);
+
+    expect(result).toEqual({ count: 0, summaries: [] });
+    expect(opalFinesServiceMock.getDraftAccounts).not.toHaveBeenCalled();
+  });
+
+  it('should return { count: 0, summaries: [] } when fragment is null', async () => {
+    const mockRoute = { fragment: null } as ActivatedRouteSnapshot;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = await lastValueFrom(executeResolver(mockRoute, {} as any) as Observable<any>);
+
+    expect(result).toEqual({ count: 0, summaries: [] });
+    expect(opalFinesServiceMock.getDraftAccounts).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/routing/resolvers/fines-draft-check-and-manage-tab.resolver.ts
+++ b/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/routing/resolvers/fines-draft-check-and-manage-tab.resolver.ts
@@ -1,0 +1,27 @@
+import { inject } from '@angular/core';
+import { ActivatedRouteSnapshot, ResolveFn } from '@angular/router';
+import { of } from 'rxjs';
+import { OpalFines } from '@services/fines/opal-fines-service/opal-fines.service';
+import { IOpalFinesDraftAccountsResponse } from '@services/fines/opal-fines-service/interfaces/opal-fines-draft-account-data.interface';
+import { FINES_DRAFT_TAB_STATUSES } from '../../../constants/fines-draft-tab-statuses.constant';
+import { GlobalStore } from '@hmcts/opal-frontend-common/stores/global';
+
+export const finesDraftCheckAndManageTabResolver: ResolveFn<IOpalFinesDraftAccountsResponse> = (
+  route: ActivatedRouteSnapshot,
+) => {
+  const opalFinesService = inject(OpalFines);
+  const globalStore = inject(GlobalStore);
+  const fragment = route.fragment;
+  const statuses = fragment ? FINES_DRAFT_TAB_STATUSES.find((tab) => tab.tab === fragment)?.statuses : null;
+
+  if (!statuses) {
+    return of({ count: 0, summaries: [] });
+  }
+
+  const userState = globalStore.userState();
+  const businessUnitIds = userState.business_unit_user.map((u) => u.business_unit_id);
+  const businessUnitUserIds = userState.business_unit_user.map((u) => u.business_unit_user_id);
+
+  const params = { businessUnitIds, statuses, submittedBy: businessUnitUserIds };
+  return opalFinesService.getDraftAccounts(params);
+};

--- a/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/routing/resolvers/fines-draft-check-and-manage-view-all-rejected.resolver.ts
+++ b/src/app/flows/fines/fines-draft/fines-draft-check-and-manage/routing/resolvers/fines-draft-check-and-manage-view-all-rejected.resolver.ts
@@ -1,0 +1,24 @@
+import { inject } from '@angular/core';
+import { ResolveFn } from '@angular/router';
+import { of } from 'rxjs';
+import { OpalFines } from '@services/fines/opal-fines-service/opal-fines.service';
+import { IOpalFinesDraftAccountsResponse } from '@services/fines/opal-fines-service/interfaces/opal-fines-draft-account-data.interface';
+import { FINES_DRAFT_TAB_STATUSES } from '../../../constants/fines-draft-tab-statuses.constant';
+import { GlobalStore } from '@hmcts/opal-frontend-common/stores/global';
+
+export const finesDraftCheckAndManageViewAllRejectedResolver: ResolveFn<IOpalFinesDraftAccountsResponse> = () => {
+  const opalFinesService = inject(OpalFines);
+  const globalStore = inject(GlobalStore);
+
+  const userState = globalStore.userState();
+  const businessUnitIds = userState.business_unit_user.map((u) => u.business_unit_id);
+  const businessUnitUserIds = userState.business_unit_user.map((u) => u.business_unit_user_id);
+
+  const statuses = FINES_DRAFT_TAB_STATUSES.find((tab) => tab.tab === 'rejected')?.statuses;
+  if (!statuses) {
+    return of({ count: 0, summaries: [] });
+  }
+
+  const params = { businessUnitIds, statuses, notSubmittedBy: businessUnitUserIds };
+  return opalFinesService.getDraftAccounts(params);
+};

--- a/src/app/flows/fines/fines-draft/services/fines-draft.service.spec.ts
+++ b/src/app/flows/fines/fines-draft/services/fines-draft.service.spec.ts
@@ -1,0 +1,45 @@
+import { OPAL_FINES_DRAFT_ACCOUNTS_MOCK } from '@services/fines/opal-fines-service/mocks/opal-fines-draft-accounts.mock';
+import { FinesDraftService } from './fines-draft.service';
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+
+describe('FinesDraftService', () => {
+  let service: FinesDraftService;
+  let mockRouter: jasmine.SpyObj<Router>;
+
+  beforeEach(() => {
+    mockRouter = jasmine.createSpyObj('Router', ['navigate']);
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: Router, useValue: mockRouter }],
+    });
+    service = TestBed.inject(FinesDraftService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should handle defendant click', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    spyOn<any>(service, 'navigateToReviewAccount');
+
+    service.onDefendantClick(1, 'test');
+
+    expect(service['navigateToReviewAccount']).toHaveBeenCalledWith(1, 'test');
+  });
+
+  it('should populate table data correctly', () => {
+    const response = OPAL_FINES_DRAFT_ACCOUNTS_MOCK;
+    const tableData = service['populateTableData'](response);
+    expect(tableData.length).toEqual(response.summaries.length);
+    expect(tableData[0]['Defendant id']).toEqual(response.summaries[0].draft_account_id);
+  });
+
+  it('should navigate to review account', () => {
+    const draftAccountId = 1;
+    const path = 'test';
+    service['navigateToReviewAccount'](draftAccountId, path);
+    expect(mockRouter.navigate).toHaveBeenCalledWith([path, draftAccountId]);
+  });
+});

--- a/src/app/flows/fines/fines-draft/services/fines-draft.service.ts
+++ b/src/app/flows/fines/fines-draft/services/fines-draft.service.ts
@@ -1,0 +1,58 @@
+import { inject, Injectable } from '@angular/core';
+import { DateService } from '@hmcts/opal-frontend-common/services/date-service';
+import { IOpalFinesDraftAccountsResponse } from '@services/fines/opal-fines-service/interfaces/opal-fines-draft-account-data.interface';
+import { FINES_MAC_ACCOUNT_TYPES } from '../../fines-mac/constants/fines-mac-account-types';
+import { IFinesDraftTableWrapperTableData } from '../fines-draft-table-wrapper/interfaces/fines-draft-table-wrapper-table-data.interface';
+import { Router } from '@angular/router';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class FinesDraftService {
+  private readonly router = inject(Router);
+  private readonly dateService = inject(DateService);
+
+  /**
+   * Populates table data from the given response.
+   *
+   * @param {IOpalFinesDraftAccountsResponse} response - The response containing draft account summaries.
+   * @returns {IFinesDraftTableWrapperTableData[]} An array of table data objects.
+   */
+  public populateTableData(response: IOpalFinesDraftAccountsResponse): IFinesDraftTableWrapperTableData[] {
+    return response.summaries.map(({ draft_account_id, account_snapshot }) => {
+      const { defendant_name, date_of_birth, created_date, account_type, business_unit_name } = account_snapshot;
+
+      return {
+        Account: '',
+        'Defendant id': draft_account_id,
+        Defendant: defendant_name,
+        'Date of birth': date_of_birth,
+        CreatedDate: created_date,
+        Created: this.dateService.getDaysAgo(created_date),
+        'Account type': FINES_MAC_ACCOUNT_TYPES[account_type as keyof typeof FINES_MAC_ACCOUNT_TYPES],
+        'Business unit': business_unit_name,
+      };
+    });
+  }
+
+  /**
+   * Navigates to the review account page for the given draft account ID.
+   *
+   * @param draftAccountId - The ID of the draft account to review.
+   * @returns void
+   */
+  private navigateToReviewAccount(draftAccountId: number, path: string): void {
+    this.router.navigate([path, draftAccountId]);
+  }
+
+  /**
+   * Handles the click event on a defendant item.
+   * Navigates to the review account page for the specified defendant.
+   *
+   * @param {number} id - The unique identifier of the defendant.
+   * @returns {void}
+   */
+  public onDefendantClick(id: number, path: string): void {
+    this.navigateToReviewAccount(id, path);
+  }
+}

--- a/src/app/flows/fines/fines-draft/stores/fines-draft.store.spec.ts
+++ b/src/app/flows/fines/fines-draft/stores/fines-draft.store.spec.ts
@@ -166,4 +166,14 @@ describe('FinesDraftStore', () => {
     store.resetBannerMessage();
     expect(store.bannerMessage()).toEqual('');
   });
+
+  it('should set view all accounts', () => {
+    store.setViewAllAccounts(true);
+    expect(store.viewAllAccounts()).toEqual(true);
+  });
+
+  it('should reset view all accounts', () => {
+    store.setViewAllAccounts(false);
+    expect(store.viewAllAccounts()).toEqual(false);
+  });
 });

--- a/src/app/flows/fines/fines-draft/stores/fines-draft.store.ts
+++ b/src/app/flows/fines/fines-draft/stores/fines-draft.store.ts
@@ -22,6 +22,7 @@ export const FinesDraftStore = signalStore(
     account_status_date: '' as string | null,
     fragment: '',
     amend: false,
+    viewAllAccounts: false,
     bannerMessage: '',
   })),
   withHooks((store) => {
@@ -118,6 +119,9 @@ export const FinesDraftStore = signalStore(
     },
     setFragmentAndAmend(fragment: string, state: boolean) {
       patchState(store, { fragment, amend: state });
+    },
+    setViewAllAccounts: (viewAllAccounts: boolean) => {
+      patchState(store, { viewAllAccounts });
     },
     resetFragmentAndAmend() {
       patchState(store, { fragment: '', amend: false });

--- a/src/app/flows/fines/fines-mac/fines-mac-review-account/fines-mac-review-account.component.html
+++ b/src/app/flows/fines/fines-mac/fines-mac-review-account/fines-mac-review-account.component.html
@@ -11,6 +11,7 @@
           : finesMacStore.getPersonalDetailsName()
       "
       [timelineData]="finesDraftStore.timeline_data()"
+      [isRejected]="reviewAccountStatus === 'Rejected'"
     ></app-fines-mac-review-account-history>
   }
 
@@ -39,12 +40,14 @@
     <app-fines-mac-review-account-company-details
       [companyDetails]="finesMacStore.companyDetails().formData"
       (emitChangeCompanyDetails)="navigateBack()"
+      [isReadOnly]="isReadOnly"
     >
     </app-fines-mac-review-account-company-details>
   }
 
   <app-fines-mac-review-account-contact-details
     [contactDetails]="finesMacStore.contactDetails().formData"
+    [isReadOnly]="isReadOnly"
     (emitChangeContactDetails)="navigateBack()"
   ></app-fines-mac-review-account-contact-details>
 
@@ -55,6 +58,7 @@
   @if (finesMacStore.accountDetails().formData.fm_create_account_defendant_type !== 'company') {
     <app-fines-mac-review-account-employer-details
       [employerDetails]="finesMacStore.employerDetails().formData"
+      [isReadOnly]="isReadOnly"
       (emitChangeEmployerDetails)="navigateBack()"
     ></app-fines-mac-review-account-employer-details>
   }
@@ -68,11 +72,13 @@
     [paymentTermsState]="finesMacStore.paymentTerms().formData"
     [businessUnit]="finesMacStore.businessUnit()"
     [defendantType]="finesMacStore.accountDetails().formData.fm_create_account_defendant_type!"
+    [isReadOnly]="isReadOnly"
     (emitChangePaymentTerms)="navigateBack()"
   ></app-fines-mac-review-account-payment-terms>
 
   <app-fines-mac-review-account-account-comments-and-notes
     [accountCommentsAndNotes]="finesMacStore.accountCommentsNotes().formData"
+    [isReadOnly]="isReadOnly"
     (emitChangeAccountCommentsAndNotesDetails)="navigateBack()"
   ></app-fines-mac-review-account-account-comments-and-notes>
 

--- a/src/app/flows/fines/fines-mac/fines-mac-review-account/fines-mac-review-account.component.spec.ts
+++ b/src/app/flows/fines/fines-mac/fines-mac-review-account/fines-mac-review-account.component.spec.ts
@@ -198,6 +198,16 @@ describe('FinesMacReviewAccountComponent', () => {
     expect(handleRequestErrorSpy).toHaveBeenCalled();
   });
 
+  it('should handle submitPayload failure', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const handleRequestErrorSpy = spyOn<any>(component, 'handleRequestError');
+    mockOpalFinesService.putDraftAddAccountPayload = jasmine
+      .createSpy('putDraftAddAccountPayload')
+      .and.returnValue(throwError(() => new Error('Something went wrong')));
+    component['handlePutRequest'](FINES_MAC_PAYLOAD_ADD_ACCOUNT);
+    expect(handleRequestErrorSpy).toHaveBeenCalled();
+  });
+
   it('should test processPutResponse', () => {
     const handleRouteSpy = spyOn(component, 'handleRoute');
     const expectedResult = structuredClone(FINES_MAC_PAYLOAD_ADD_ACCOUNT);
@@ -335,6 +345,16 @@ describe('FinesMacReviewAccountComponent', () => {
     );
   });
 
+  it('should navigate back to view-all-rejected on navigateBack when isReadOnly is true and viewAllAccounts is true', () => {
+    const routerSpy = spyOn(component['router'], 'navigate');
+    finesDraftStore.setViewAllAccounts(true);
+    component.isReadOnly = true;
+    component.navigateBack();
+    expect(routerSpy).toHaveBeenCalledWith([
+      `${component['finesRoutes'].root}/${component['finesDraftRoutes'].root}/${component['finesDraftRoutes'].children.createAndManage}/${component['finesDraftCheckAndManageRoutes'].children.viewAllRejected}`,
+    ]);
+  });
+
   it('should submit payload on submitForReview', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const submitPayloadSpy = spyOn<any>(component, 'submitPayload').and.callThrough();
@@ -350,6 +370,16 @@ describe('FinesMacReviewAccountComponent', () => {
     component.handleRoute('test');
 
     expect(routerSpy).toHaveBeenCalledWith(['test'], { relativeTo: component['activatedRoute'].parent });
+  });
+
+  it('should navigate on handleRoute with event', () => {
+    const routerSpy = spyOn(component['router'], 'navigate');
+    const event = jasmine.createSpyObj(Event, ['preventDefault']);
+
+    component.handleRoute('test', true, event);
+
+    expect(routerSpy).toHaveBeenCalledWith(['test']);
+    expect(event.preventDefault).toHaveBeenCalled();
   });
 
   it('should navigate on handleRoute to delete account', () => {
@@ -381,5 +411,11 @@ describe('FinesMacReviewAccountComponent', () => {
 
     expect(finesMacStore.getFinesMacStore()).toEqual(FINES_MAC_STATE);
     expect(finesDraftStore.getFinesDraftState()).toEqual(FINES_DRAFT_STATE);
+  });
+
+  it('should scroll to top and return null on handleRequestError', () => {
+    const result = component['handleRequestError']();
+    expect(mockUtilsService.scrollToTop).toHaveBeenCalled();
+    expect(result).toBeNull();
   });
 });

--- a/src/app/flows/fines/fines-mac/fines-mac-review-account/fines-mac-review-account.component.ts
+++ b/src/app/flows/fines/fines-mac/fines-mac-review-account/fines-mac-review-account.component.ts
@@ -316,12 +316,17 @@ export class FinesMacReviewAccountComponent implements OnInit, OnDestroy {
     if (this.isReadOnly) {
       this.finesMacStore.setUnsavedChanges(false);
       this.finesMacStore.setStateChanges(false);
-      this.handleRoute(
-        `${this.finesRoutes.root}/${this.finesDraftRoutes.root}/${this.finesDraftRoutes.children.createAndManage}/${this.finesDraftCheckAndManageRoutes.children.tabs}`,
-        false,
-        undefined,
-        this.finesDraftStore.fragment(),
-      );
+      const path = this.finesDraftStore.viewAllAccounts()
+        ? `${this.finesRoutes.root}/${this.finesDraftRoutes.root}/${this.finesDraftRoutes.children.createAndManage}/${this.finesDraftCheckAndManageRoutes.children.viewAllRejected}`
+        : `${this.finesRoutes.root}/${this.finesDraftRoutes.root}/${this.finesDraftRoutes.children.createAndManage}/${this.finesDraftCheckAndManageRoutes.children.tabs}`;
+
+      // return true when going back to view-all-accounts
+      // and false when going back to tabbed fragment
+      if (this.finesDraftStore.viewAllAccounts()) {
+        this.handleRoute(path, true);
+      } else {
+        this.handleRoute(path, false, undefined, this.finesDraftStore.fragment());
+      }
     } else {
       this.handleRoute(this.finesMacRoutes.children.accountDetails);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7814,11 +7814,11 @@ __metadata:
   linkType: hard
 
 "csrf-csrf@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "csrf-csrf@npm:4.0.1"
+  version: 4.0.2
+  resolution: "csrf-csrf@npm:4.0.2"
   dependencies:
     http-errors: "npm:^2.0.0"
-  checksum: 10/3ddcd68f54072a299de3edfb2531868185c477d23f42bf9700252843b56b9c530e1f634b0147d9cf67ad73add7b8da37ba6e2bc6a1247aba6426c04dfdd34df3
+  checksum: 10/2c3f1679aaa1368a1e3349ba719f6fb8ae43ab83e91c442ac1ecc8d60aa4142b1c46ec24d6578986f1136f1a0c6c96fea93bfa1692f034f90769f989877b07db
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Jira link
[PO-618](https://tools.hmcts.net/jira/browse/PO-618)

### Change description
- View all rejected accounts now shows data 
- New resolvers for viewing tabbed data on load, then async pipe refreshes data
- New resolver for getting rejected account count on load, then async pipe refreshes count
- New resolver for getting all rejected accounts
- Unit tests updated 
- New fines draft service to reduce code duplication across tab/view all rejected components

### Testing done
- Unit tests updated and built
- Working locally as expected

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
