### PR TITLE
PO-1844

### DIFF
--- a/src/app/flows/fines/fines-draft/fines-draft-check-and-validate/fines-draft-check-and-validate-tabs/fines-draft-check-and-validate-tabs.component.html
+++ b/src/app/flows/fines/fines-draft/fines-draft-check-and-validate/fines-draft-check-and-validate-tabs/fines-draft-check-and-validate-tabs.component.html
@@ -1,24 +1,27 @@
 <div class="govuk-grid-column-full">
   <h1 class="govuk-heading-l">Review accounts</h1>
   <opal-lib-moj-sub-navigation subNavId="checker-tabs" (activeSubNavItemFragment)="handleTabSwitch($event)">
-    <opal-lib-moj-sub-navigation-item
+    <li
+      opal-lib-moj-sub-navigation-item
       subNavItemId="checker-to-review-tab"
       [activeSubNavItemFragment]="activeTab"
       subNavItemFragment="to-review"
       subNavItemText="To review"
-    ></opal-lib-moj-sub-navigation-item>
-    <opal-lib-moj-sub-navigation-item
+    ></li>
+    <li
+      opal-lib-moj-sub-navigation-item
       subNavItemId="checker-rejected-tab"
       [activeSubNavItemFragment]="activeTab"
       subNavItemFragment="rejected"
       subNavItemText="Rejected"
-    ></opal-lib-moj-sub-navigation-item>
-    <opal-lib-moj-sub-navigation-item
+    ></li>
+    <li
+      opal-lib-moj-sub-navigation-item
       subNavItemId="checker-deleted-tab"
       [activeSubNavItemFragment]="activeTab"
       subNavItemFragment="deleted"
       subNavItemText="Deleted"
-    ></opal-lib-moj-sub-navigation-item>
+    ></li>
   </opal-lib-moj-sub-navigation>
   @switch (activeTab) {
     @case ('to-review') {

--- a/src/app/flows/fines/fines-draft/fines-draft-create-and-manage/fines-draft-create-and-manage-tabs/fines-draft-create-and-manage-tabs.component.html
+++ b/src/app/flows/fines/fines-draft/fines-draft-create-and-manage/fines-draft-create-and-manage-tabs/fines-draft-create-and-manage-tabs.component.html
@@ -4,14 +4,16 @@
   }
   <h1 class="govuk-heading-l">Create accounts</h1>
   <opal-lib-moj-sub-navigation subNavId="inputter-tabs" (activeSubNavItemFragment)="handleTabSwitch($event)">
-    <opal-lib-moj-sub-navigation-item
+    <li
+      opal-lib-moj-sub-navigation-item
       subNavItemId="inputter-in-review-tab"
       [activeSubNavItemFragment]="activeTab"
       subNavItemFragment="review"
       subNavItemText="In review"
-    ></opal-lib-moj-sub-navigation-item>
+    ></li>
     @if (rejectedCount$ | async; as rejectedCount) {
-      <opal-lib-moj-sub-navigation-item
+      <li
+        opal-lib-moj-sub-navigation-item
         subNavItemId="inputter-rejected-tab"
         [activeSubNavItemFragment]="activeTab"
         subNavItemFragment="rejected"
@@ -22,20 +24,22 @@
             {{ rejectedCount }}
           </opal-lib-moj-badge>
         }
-      </opal-lib-moj-sub-navigation-item>
+      </li>
     }
-    <opal-lib-moj-sub-navigation-item
+    <li
+      opal-lib-moj-sub-navigation-item
       subNavItemId="inputter-approved-tab"
       [activeSubNavItemFragment]="activeTab"
       subNavItemFragment="approved"
       subNavItemText="Approved"
-    ></opal-lib-moj-sub-navigation-item>
-    <opal-lib-moj-sub-navigation-item
+    ></li>
+    <li
+      opal-lib-moj-sub-navigation-item
       subNavItemId="inputter-deleted-tab"
       [activeSubNavItemFragment]="activeTab"
       subNavItemFragment="deleted"
       subNavItemText="Deleted"
-    ></opal-lib-moj-sub-navigation-item>
+    ></li>
   </opal-lib-moj-sub-navigation>
   @switch (activeTab) {
     @case ('review') {

--- a/src/app/flows/fines/fines-mac/fines-mac-review-account/fines-mac-review-account-history/fines-mac-review-account-history.component.html
+++ b/src/app/flows/fines/fines-mac/fines-mac-review-account/fines-mac-review-account-history/fines-mac-review-account-history.component.html
@@ -4,7 +4,7 @@
 <opal-lib-govuk-tag [tagClasses]="isRejected ? 'govuk-tag govuk-tag--red' : 'govuk-tag'" tagId="status">{{
   accountStatus
 }}</opal-lib-govuk-tag>
-<h3 class="govuk-heading-m govuk-!-margin-top-4">Review history</h3>
+<h2 class="govuk-heading-m govuk-!-margin-top-4">Review history</h2>
 <opal-lib-moj-timeline>
   @for (timelineItem of timelineData; track $index) {
     <opal-lib-moj-timeline-item>


### PR DESCRIPTION
### Jira link
[PO-1844](https://tools.hmcts.net/jira/browse/PO-1844)

### Change description
- Change the way we use opal-lib-moj-sub-navigation-items in the fines-draft-check-and-validate-tabs and fines-draft-create-and-manage-tabs as this introduces AxeCore Issues
- Reduce the h3 to h2 in the fines-mac-review-account-history component
- Needs Common UI to be published to V0.0.16 - [PO-1844 - Common UI Lib](https://github.com/hmcts/opal-frontend-common-ui-lib/pull/96)

### Testing done
- Tested locally and no AxeCore Issue being raised on these pages anymore
- Unit tests all passing locally and working as expected

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
