### PR TITLE
PO-2075

### DIFF
--- a/src/app/flows/fines/fines-sa/fines-sa-search/fines-sa-search-account/constants/fines-sa-search-account-state.constant.ts
+++ b/src/app/flows/fines/fines-sa/fines-sa-search/fines-sa-search-account/constants/fines-sa-search-account-state.constant.ts
@@ -1,12 +1,15 @@
+import { FINES_SA_SEARCH_ACCOUNT_FORM_COMPANIES_STATE } from '../fines-sa-search-account-form/fines-sa-search-account-form-companies/constants/fines-sa-search-account-form-companies-state.constant';
+import { FINES_SA_SEARCH_ACCOUNT_FORM_INDIVIDUALS_STATE } from '../fines-sa-search-account-form/fines-sa-search-account-form-individuals/constants/fines-sa-search-account-form-individuals-state.constant';
+import { FINES_SA_SEARCH_ACCOUNT_FORM_MINOR_CREDITORS_STATE } from '../fines-sa-search-account-form/fines-sa-search-account-form-minor-creditors/constants/fines-sa-search-account-form-minor-creditors-state.constant';
 import { IFinesSaSearchAccountState } from '../interfaces/fines-sa-search-account-state.interface';
 
 export const FINES_SA_SEARCH_ACCOUNT_STATE: IFinesSaSearchAccountState = {
   fsa_search_account_business_unit_ids: null,
   fsa_search_account_number: null,
   fsa_search_account_reference_case_number: null,
-  fsa_search_account_individual_search_criteria: null,
-  fsa_search_account_companies_search_criteria: null,
-  fsa_search_account_minor_creditors_search_criteria: null,
+  fsa_search_account_individual_search_criteria: FINES_SA_SEARCH_ACCOUNT_FORM_INDIVIDUALS_STATE,
+  fsa_search_account_companies_search_criteria: FINES_SA_SEARCH_ACCOUNT_FORM_COMPANIES_STATE,
+  fsa_search_account_minor_creditors_search_criteria: FINES_SA_SEARCH_ACCOUNT_FORM_MINOR_CREDITORS_STATE,
   fsa_search_account_major_creditor_search_criteria: null,
   fsa_search_account_active_accounts_only: true,
 };

--- a/src/app/flows/fines/fines-sa/stores/fines-sa.store.spec.ts
+++ b/src/app/flows/fines/fines-sa/stores/fines-sa.store.spec.ts
@@ -51,16 +51,10 @@ describe('FinesSaStore', () => {
     expect(store.unsavedChanges()).toBeTrue();
   });
 
-  it('should reset search criteria only', () => {
-    store.setSearchAccount({ ...FINES_SA_SEARCH_ACCOUNT_STATE, fsa_search_account_number: 'reset-me' });
-    store.resetDefendantSearchCriteria();
-    expect(store.searchAccount().fsa_search_account_individual_search_criteria).toEqual(null);
-  });
-
   it('should reset only the searchAccount object', () => {
     store.setSearchAccount({ ...FINES_SA_SEARCH_ACCOUNT_STATE, fsa_search_account_number: 'abc' });
     store.resetSearchAccount();
-    expect(store.searchAccount()).toEqual({} as IFinesSaSearchAccountState);
+    expect(store.searchAccount()).toEqual(FINES_SA_SEARCH_ACCOUNT_STATE);
   });
 
   it('should reset stateChanges and unsavedChanges', () => {
@@ -78,7 +72,7 @@ describe('FinesSaStore', () => {
     store.setUnsavedChanges(true);
 
     store.resetStore();
-    expect(store.searchAccount()).toEqual({} as IFinesSaSearchAccountState);
+    expect(store.searchAccount()).toEqual(FINES_SA_SEARCH_ACCOUNT_STATE);
     expect(store.activeTab()).toBe('individuals');
     expect(store.stateChanges()).toBeFalse();
     expect(store.unsavedChanges()).toBeFalse();

--- a/src/app/flows/fines/fines-sa/stores/fines-sa.store.ts
+++ b/src/app/flows/fines/fines-sa/stores/fines-sa.store.ts
@@ -19,7 +19,7 @@ export const FinesSaStore = signalStore(
     return {
       onDestroy() {
         patchState(store, {
-          searchAccount: {} as IFinesSaSearchAccountState,
+          searchAccount: FINES_SA_SEARCH_ACCOUNT_STATE,
           activeTab: 'individuals' as FinesSaSearchAccountTab,
           stateChanges: false,
           unsavedChanges: false,
@@ -67,17 +67,9 @@ export const FinesSaStore = signalStore(
         unsavedChanges,
       });
     },
-    resetDefendantSearchCriteria: () => {
-      patchState(store, {
-        searchAccount: {
-          ...store.searchAccount(),
-          fsa_search_account_defendant_search_criteria: {},
-        } as IFinesSaSearchAccountState,
-      });
-    },
     resetSearchAccount: () => {
       patchState(store, {
-        searchAccount: {} as IFinesSaSearchAccountState,
+        searchAccount: FINES_SA_SEARCH_ACCOUNT_STATE,
       });
     },
     resetStateChangesUnsavedChanges: () => {
@@ -85,7 +77,7 @@ export const FinesSaStore = signalStore(
     },
     resetStore: () =>
       patchState(store, {
-        searchAccount: {} as IFinesSaSearchAccountState,
+        searchAccount: FINES_SA_SEARCH_ACCOUNT_STATE,
         activeTab: 'individuals' as FinesSaSearchAccountTab,
         stateChanges: false,
         unsavedChanges: false,


### PR DESCRIPTION
### Jira link
[PO-2075](https://tools.hmcts.net/jira/browse/PO-2075)

### Change description
- Addressed bug whereby if a user populated the individual tab with data. Left Search Account (i.e. back to the dashboard) then back into Search Account the data the user had previous populated remained on the form. This fix prevents this from happening so all values are null when the user navigates to the screen

### Testing done
- Tested locally and working as expected

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
