### PR TITLE
Update bank_account_type from number to string

### DIFF
--- a/cypress/fixtures/draftAccounts/parentOrGuardianPayload.json
+++ b/cypress/fixtures/draftAccounts/parentOrGuardianPayload.json
@@ -120,7 +120,7 @@
               "email_address": null,
               "payout_hold": true,
               "pay_by_bacs": true,
-              "bank_account_type": 1,
+              "bank_account_type": "1",
               "bank_sort_code": "123456",
               "bank_account_number": "12345678",
               "bank_account_name": "F LNAME",

--- a/src/app/flows/fines/fines-mac/services/fines-mac-payload/utils/fines-mac-payload-build-account/fines-mac-payload-build-account-offences.utils.spec.ts
+++ b/src/app/flows/fines/fines-mac/services/fines-mac-payload/utils/fines-mac-payload-build-account/fines-mac-payload-build-account-offences.utils.spec.ts
@@ -258,7 +258,7 @@ describe('finesMacPayloadBuildAccountOffences', () => {
               email_address: null,
               payout_hold: false,
               pay_by_bacs: false,
-              bank_account_type: 1,
+              bank_account_type: '1',
               bank_sort_code: null,
               bank_account_number: null,
               bank_account_name: null,

--- a/src/app/flows/fines/fines-mac/services/fines-mac-payload/utils/fines-mac-payload-build-account/fines-mac-payload-build-account-offences.utils.ts
+++ b/src/app/flows/fines/fines-mac/services/fines-mac-payload/utils/fines-mac-payload-build-account/fines-mac-payload-build-account-offences.utils.ts
@@ -69,7 +69,7 @@ const buildAccountOffencesImpositionsMinorCreditorPayload = (
     email_address: null,
     payout_hold: payoutOnHold,
     pay_by_bacs: payByBacs,
-    bank_account_type: 1,
+    bank_account_type: '1',
     bank_sort_code: childFormData?.formData.fm_offence_details_minor_creditor_bank_sort_code ?? null,
     bank_account_number: childFormData?.formData.fm_offence_details_minor_creditor_bank_account_number ?? null,
     bank_account_name: childFormData?.formData.fm_offence_details_minor_creditor_bank_account_name ?? null,

--- a/src/app/flows/fines/fines-mac/services/fines-mac-payload/utils/interfaces/fines-mac-payload-account-offences.interface.ts
+++ b/src/app/flows/fines/fines-mac/services/fines-mac-payload/utils/interfaces/fines-mac-payload-account-offences.interface.ts
@@ -13,7 +13,7 @@ export interface IFinesMacPayloadAccountOffencesMinorCreditor {
   email_address: string | null;
   payout_hold: boolean | null;
   pay_by_bacs: boolean;
-  bank_account_type: number | null;
+  bank_account_type: string | null;
   bank_sort_code: string | null;
   bank_account_number: string | null;
   bank_account_name: string | null;

--- a/src/app/flows/fines/fines-mac/services/fines-mac-payload/utils/mocks/fines-mac-payload-account-offences-with-minor-creditor.mock.ts
+++ b/src/app/flows/fines/fines-mac/services/fines-mac-payload/utils/mocks/fines-mac-payload-account-offences-with-minor-creditor.mock.ts
@@ -26,7 +26,7 @@ export const FINES_MAC_PAYLOAD_ACCOUNT_OFFENCES_WITH_MINOR_CREDITOR: IFinesMacPa
           email_address: null,
           payout_hold: true,
           pay_by_bacs: true,
-          bank_account_type: 1,
+          bank_account_type: '1',
           bank_sort_code: '000000',
           bank_account_number: '01010101',
           bank_account_name: 'Mr Test Test',


### PR DESCRIPTION
### Jira link
[PO-1988](https://tools.hmcts.net/jira/browse/PO-1988)

### Change description
As part of changes to the database [PO-1043](https://tools.hmcts.net/jira/browse/PO-1043) and changes to the backend [PO-1987](https://tools.hmcts.net/jira/browse/PO-1987) we have to change the field `bank_account_type` from number to string. This means that in the payload generation we send `"1"` instead of `1`

### Testing done
- Unit tests passing locally
- To be tested in Pull Request with the PR from the backend [PO-1034 PO-1035 PO-1036 PO-1038 PO-1039 PO-1040 PO-1041 PO-1042 PO-1043 PO-1044 PO-1591 P0-19950 to add more functionality to Manual Account Creation](https://github.com/hmcts/opal-fines-service/pull/1071)

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
