### PR TITLE
refactor: update business unit filtering to use business_unit_type instead of opal_domain

### DIFF
--- a/src/app/flows/fines/fines-sa/fines-sa-search/fines-sa-search-account/fines-sa-search-account.component.spec.ts
+++ b/src/app/flows/fines/fines-sa/fines-sa-search/fines-sa-search-account/fines-sa-search-account.component.spec.ts
@@ -131,10 +131,10 @@ describe('FinesSaSearchAccountComponent', () => {
     });
 
     const refData = [
-      { business_unit_id: 1, opal_domain: 'Fines' },
-      { business_unit_id: 2, opal_domain: '' },
-      { business_unit_id: 3, opal_domain: undefined },
-      { business_unit_id: 4, opal_domain: 'Confiscation' },
+      { business_unit_id: 1, business_unit_type: 'Accounting Division' },
+      { business_unit_id: 2, business_unit_type: '' },
+      { business_unit_id: 3, business_unit_type: undefined },
+      { business_unit_id: 4, business_unit_type: 'Accounting Division' },
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ] as any[];
 

--- a/src/app/flows/fines/fines-sa/fines-sa-search/fines-sa-search-account/fines-sa-search-account.component.ts
+++ b/src/app/flows/fines/fines-sa/fines-sa-search/fines-sa-search-account/fines-sa-search-account.component.ts
@@ -38,7 +38,7 @@ export class FinesSaSearchAccountComponent extends AbstractFormParentBaseCompone
    * has a default search account business unit selection.
    *
    * - Reads resolver data from the activated route snapshot.
-   * - Filters the refData to only include business units that have an `opal_domain`.
+   * - Filters the refData to only include business units that have a business unit type of `Accounting Division`.
    * - Assigns the filtered array to `this.businessUnitRefData`.
    * - If the store's search account does not already have `fsa_search_account_business_unit_ids`,
    *   initializes the search account state with the IDs of the filtered business units.
@@ -49,7 +49,9 @@ export class FinesSaSearchAccountComponent extends AbstractFormParentBaseCompone
   private getBusinessUnits(): void {
     const resolverData = this['activatedRoute']?.snapshot?.data?.['businessUnits'];
     const refData = resolverData?.refData as IOpalFinesBusinessUnit[] | undefined;
-    this.businessUnitRefData = Array.isArray(refData) ? refData.filter((bu) => Boolean(bu?.opal_domain)) : [];
+    this.businessUnitRefData = Array.isArray(refData)
+      ? refData.filter((bu) => bu.business_unit_type === 'Accounting Division')
+      : [];
     if (!this.finesSaStore.searchAccount().fsa_search_account_business_unit_ids) {
       this.finesSaStore.setSearchAccount({
         ...FINES_SA_SEARCH_ACCOUNT_STATE,

--- a/src/app/flows/fines/fines-sa/fines-sa-search/fines-sa-search-filter-business-unit/fines-sa-search-filter-business-unit.component.ts
+++ b/src/app/flows/fines/fines-sa/fines-sa-search/fines-sa-search-filter-business-unit/fines-sa-search-filter-business-unit.component.ts
@@ -25,8 +25,8 @@ export class FinesSaSearchFilterBusinessUnitComponent extends AbstractFormParent
    *
    * Reads the resolver payload at `activatedRoute.snapshot.data['businessUnits']`, expects a
    * `refData` property of type `IOpalFinesBusinessUnit[] | undefined`, and sets `this.businessUnits`
-   * to the filtered array of business units that have a truthy `opal_domain`. If `refData` is not
-   * an array or is undefined, `this.businessUnits` is set to an empty array.
+   * to the filtered array of business units that have `Accounting Division` as their type of `business_unit_type`.
+   * If `refData` is not an array or is undefined, `this.businessUnits` is set to an empty array.
    *
    * @private
    * @returns void
@@ -34,7 +34,9 @@ export class FinesSaSearchFilterBusinessUnitComponent extends AbstractFormParent
   private populateBusinessUnitFromResolver(): void {
     const resolverData = this['activatedRoute']?.snapshot?.data?.['businessUnits'];
     const refData = resolverData?.refData as IOpalFinesBusinessUnit[] | undefined;
-    this.businessUnits = Array.isArray(refData) ? refData.filter((bu) => Boolean(bu?.opal_domain)) : [];
+    this.businessUnits = Array.isArray(refData)
+      ? refData.filter((bu) => bu.business_unit_type === 'Accounting Division')
+      : [];
   }
 
   /**


### PR DESCRIPTION
### Jira link
- N/A

### Change description
- After speaking with Abe, he mentioned the best way of filtering the business units is by filtering by business_unit_type being `Accounting Division`. Update the filtering that was put in place for the Filter by business unit screen in the Search & Matches journey

### Testing done
- All unit tests working as expected

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
