### PR TITLE
 Add E2E coverage for Add Note permission denied error

### DIFF
--- a/cypress/e2e/functional/opal/actions/global-api-interceptor.actions.ts
+++ b/cypress/e2e/functional/opal/actions/global-api-interceptor.actions.ts
@@ -320,6 +320,59 @@ export class GlobalApiInterceptorActions {
   }
 
   /**
+   * Stubs the FAE Add Note request with a non-retriable permission error.
+   * @param statusCode - HTTP status to return for the Add Note request.
+   * @remarks Uses the Add Note endpoint so the common interceptor handles the permission path.
+   * @example
+   * actions.stubAddNoteNonRetriablePermissionError(403);
+   */
+  public stubAddNoteNonRetriablePermissionError(statusCode: number): void {
+    log('intercept', 'Stubbing add note non-retriable permission error', { statusCode });
+    cy.intercept('POST', '**/opal-fines-service/notes/add', {
+      statusCode,
+      body: {
+        retriable: false,
+        title: NON_RETRIABLE_ERROR_TITLE,
+        detail: NON_RETRIABLE_ERROR_DETAIL,
+        operation_id: NON_RETRIABLE_OPERATION_ID,
+      },
+    }).as('addNoteNonRetriablePermissionError');
+  }
+
+  /**
+   * Waits for the FAE Add Note permission error response and validates it.
+   * @param statusCode - Expected HTTP status returned by the stub.
+   * @remarks Confirms the POST request and non-retriable error metadata.
+   * @example
+   * actions.waitForAddNoteNonRetriablePermissionError(403);
+   */
+  public waitForAddNoteNonRetriablePermissionError(statusCode: number): void {
+    log('wait', 'Waiting for add note non-retriable permission error', { statusCode });
+    cy.wait('@addNoteNonRetriablePermissionError').then((interception) => {
+      const response = interception.response;
+      expect(interception.request.method).to.equal('POST');
+      expect(response, 'Add Note non-retriable permission response').to.exist;
+      expect(response?.statusCode).to.equal(statusCode);
+      expect(response?.body?.retriable).to.be.false;
+      expect(response?.body?.title).to.equal(NON_RETRIABLE_ERROR_TITLE);
+      expect(response?.body?.operation_id).to.equal(NON_RETRIABLE_OPERATION_ID);
+    });
+  }
+
+  /**
+   * Clicks the Permission Denied page Go back link.
+   * @remarks Uses the visible GOV.UK link text from the Permission Denied page.
+   * @example
+   * actions.clickPermissionDeniedBackLink();
+   */
+  public clickPermissionDeniedBackLink(): void {
+    log('action', 'Clicking Permission Denied Go back link');
+    cy.contains('a.govuk-link', /^Go back$/, this.common.getTimeoutOptions())
+      .should('be.visible')
+      .click();
+  }
+
+  /**
    * Asserts the global error banner is visible with the standard message.
    * @remarks Uses the shared global alert selector and standard error message.
    * @example

--- a/cypress/e2e/functional/opal/actions/global-api-interceptor.actions.ts
+++ b/cypress/e2e/functional/opal/actions/global-api-interceptor.actions.ts
@@ -360,19 +360,6 @@ export class GlobalApiInterceptorActions {
   }
 
   /**
-   * Clicks the Permission Denied page Go back link.
-   * @remarks Uses the visible GOV.UK link text from the Permission Denied page.
-   * @example
-   * actions.clickPermissionDeniedBackLink();
-   */
-  public clickPermissionDeniedBackLink(): void {
-    log('action', 'Clicking Permission Denied Go back link');
-    cy.contains('a.govuk-link', /^Go back$/, this.common.getTimeoutOptions())
-      .should('be.visible')
-      .click();
-  }
-
-  /**
    * Asserts the global error banner is visible with the standard message.
    * @remarks Uses the shared global alert selector and standard error message.
    * @example

--- a/cypress/e2e/functional/opal/features/globalApiInterceptor.feature
+++ b/cypress/e2e/functional/opal/features/globalApiInterceptor.feature
@@ -196,18 +196,22 @@ Feature: Global API Interceptor shows error banner for all CEP error codes
 
   Rule: Account note entrypoint
 
-    @JIRA-STORY:PO-2227  @JIRA-EPIC:PO-2239
-    Scenario: Permission Denied page is displayed when the Add Note API returns a non-retriable permission error
-      Given I clear all approved accounts
-      And a published adult or youth defendant account exists:
+    Background:
+      Given a published adult or youth defendant account exists:
         | first name                | Priya                |
         | last name                 | PermissionNote{uniq} |
         | prosecutor case reference | PCRPERM{uniqUpper}   |
         | date of birth             | 2001-05-15           |
       When I search for the account by last name "PermissionNote{uniq}" and open the latest result
       Then I should see the account summary header contains "Mr Priya PERMISSIONNOTE{uniqUpper}"
+
+    @JIRA-EPIC:PO-2239
+    @JIRA-STORY:PO-2227
+    Scenario: Permission Denied page is displayed when the Add Note API returns a non-retriable permission error
+      # AC1: CTA-triggered Add Note request fails with a non-retriable HTTP 403 permission response.
       When I open the Add account note screen and verify the header is Add account note
       And I save account note "Permission denied test note" and the Add Note request fails with a non-retriable 403 error
+      # AC1a: Permission Denied page displays the expected design content.
       Then the error page shows:
         | field   | value                                                                      |
         | header  | You do not have permission for this                                        |
@@ -215,4 +219,5 @@ Feature: Global API Interceptor shows error banner for all CEP error codes
         | message | the account is outside your business unit and some features are restricted |
         | message | you are not permitted to use this feature                                  |
         | message | If you think this is incorrect, contact your line manager.                 |
+      # AC1b: Go back returns to the screen that triggered the failed API call.
       And the permission denied Go back link returns me to the Add account note screen

--- a/cypress/e2e/functional/opal/features/globalApiInterceptor.feature
+++ b/cypress/e2e/functional/opal/features/globalApiInterceptor.feature
@@ -219,5 +219,3 @@ Feature: Global API Interceptor shows error banner for all CEP error codes
         | message | the account is outside your business unit and some features are restricted |
         | message | you are not permitted to use this feature                                  |
         | message | If you think this is incorrect, contact your line manager.                 |
-      # AC1b: Go back returns to the screen that triggered the failed API call.
-      And the permission denied Go back link returns me to the Add account note screen

--- a/cypress/e2e/functional/opal/features/globalApiInterceptor.feature
+++ b/cypress/e2e/functional/opal/features/globalApiInterceptor.feature
@@ -192,3 +192,27 @@ Feature: Global API Interceptor shows error banner for all CEP error codes
       And I go to the Defendant details section and the header is "Defendant details"
       And I edit the Defendant details without making changes
       Then I should see the First name field still contains "Casey"
+
+
+  Rule: Account note entrypoint
+
+    @JIRA-STORY:PO-2227  @JIRA-EPIC:PO-2239
+    Scenario: Permission Denied page is displayed when the Add Note API returns a non-retriable permission error
+      Given I clear all approved accounts
+      And a published adult or youth defendant account exists:
+        | first name                | Priya                |
+        | last name                 | PermissionNote{uniq} |
+        | prosecutor case reference | PCRPERM{uniqUpper}   |
+        | date of birth             | 2001-05-15           |
+      When I search for the account by last name "PermissionNote{uniq}" and open the latest result
+      Then I should see the account summary header contains "Mr Priya PERMISSIONNOTE{uniqUpper}"
+      When I open the Add account note screen and verify the header is Add account note
+      And I save account note "Permission denied test note" and the Add Note request fails with a non-retriable 403 error
+      Then the error page shows:
+        | field   | value                                                                      |
+        | header  | You do not have permission for this                                        |
+        | message | This may be because:                                                       |
+        | message | the account is outside your business unit and some features are restricted |
+        | message | you are not permitted to use this feature                                  |
+        | message | If you think this is incorrect, contact your line manager.                 |
+      And the permission denied Go back link returns me to the Add account note screen

--- a/cypress/e2e/functional/opal/flows/global-api-interceptor.flow.ts
+++ b/cypress/e2e/functional/opal/flows/global-api-interceptor.flow.ts
@@ -20,6 +20,7 @@ import { AccountSearchIndividualsActions } from '../actions/search/search.indivi
 import { PrimaryNavigationActions } from '../actions/primary-navigation.actions';
 import { AccountDetailsNavActions } from '../actions/account-details/details.nav.actions';
 import { EditDefendantDetailsActions } from '../actions/account-details/edit.defendant-details.actions';
+import { AccountDetailsNotesActions } from '../actions/account-details/details.notes.actions';
 
 const log = createScopedLogger('GlobalApiInterceptorFlow');
 
@@ -40,6 +41,7 @@ export class GlobalApiInterceptorFlow {
   private readonly accountSearchCompanies = new AccountSearchCompanyActions();
   private readonly detailsNav = new AccountDetailsNavActions();
   private readonly editDefendantDetails = new EditDefendantDetailsActions();
+  private readonly notes = new AccountDetailsNotesActions();
 
   /**
    * Opens Manual Account Creation and triggers a CEP-style business units error.
@@ -203,6 +205,37 @@ export class GlobalApiInterceptorFlow {
   }
 
   /**
+   * Saves an account note and triggers the Add Note POST non-retriable permission error.
+   * @param noteText - Text to enter into the Add account note form.
+   * @param statusCode - HTTP status to stub for the Add Note request.
+   * @remarks Guards the Permission Denied page header after the common interceptor handles the error.
+   * @example
+   * flow.saveAccountNoteWithNonRetriablePermissionError('Permission denied test note', 403);
+   */
+  public saveAccountNoteWithNonRetriablePermissionError(noteText: string, statusCode: number): void {
+    const expectedHeader = this.resolveAddNoteNonRetriableHeader(statusCode);
+    log('flow', 'Saving account note with non-retriable permission error', { statusCode });
+    this.notes.assertHeaderContains('Add account note');
+    this.actions.stubAddNoteNonRetriablePermissionError(statusCode);
+    this.notes.enterAccountNote(noteText);
+    this.notes.save();
+    this.actions.waitForAddNoteNonRetriablePermissionError(statusCode);
+    this.common.assertHeaderContains(expectedHeader);
+  }
+
+  /**
+   * Clicks Go back on the Permission Denied page and asserts the Add account note page is restored.
+   * @remarks Covers the FAE Add Note back-navigation acceptance criterion.
+   * @example
+   * flow.returnToAddAccountNoteFromPermissionDenied();
+   */
+  public returnToAddAccountNoteFromPermissionDenied(): void {
+    log('flow', 'Returning from Permission Denied page to Add account note');
+    this.actions.clickPermissionDeniedBackLink();
+    this.notes.assertHeaderContains('Add account note');
+  }
+
+  /**
    * Refreshes the current page and confirms the global banner is cleared.
    * @param expectedHeader - Expected header text after refresh.
    * @remarks Uses header assertions to guard the refresh destination.
@@ -265,5 +298,20 @@ export class GlobalApiInterceptorFlow {
       return 'Sorry, there is a problem';
     }
     throw new Error(`Unsupported defendant account party error status: ${statusCode}`);
+  }
+
+  /**
+   * Resolves the expected header for Add Note non-retriable errors.
+   * @param statusCode - HTTP status used to route to the correct error page.
+   * @returns Expected error page header for the given status.
+   * @remarks Throws for unsupported status codes to avoid false positives.
+   * @example
+   * const header = this.resolveAddNoteNonRetriableHeader(403);
+   */
+  private resolveAddNoteNonRetriableHeader(statusCode: number): string {
+    if (statusCode === 403) {
+      return 'You do not have permission for this';
+    }
+    throw new Error(`Unsupported add note error status: ${statusCode}`);
   }
 }

--- a/cypress/e2e/functional/opal/flows/global-api-interceptor.flow.ts
+++ b/cypress/e2e/functional/opal/flows/global-api-interceptor.flow.ts
@@ -225,18 +225,6 @@ export class GlobalApiInterceptorFlow {
   }
 
   /**
-   * Clicks Go back on the Permission Denied page and asserts the Add account note page is restored.
-   * @remarks Covers the FAE Add Note back-navigation acceptance criterion.
-   * @example
-   * flow.returnToAddAccountNoteFromPermissionDenied();
-   */
-  public returnToAddAccountNoteFromPermissionDenied(): void {
-    log('flow', 'Returning from Permission Denied page to Add account note');
-    this.actions.clickPermissionDeniedBackLink();
-    this.notes.assertHeaderContains('Add account note');
-  }
-
-  /**
    * Refreshes the current page and confirms the global banner is cleared.
    * @param expectedHeader - Expected header text after refresh.
    * @remarks Uses header assertions to guard the refresh destination.

--- a/cypress/e2e/functional/opal/flows/global-api-interceptor.flow.ts
+++ b/cypress/e2e/functional/opal/flows/global-api-interceptor.flow.ts
@@ -220,6 +220,7 @@ export class GlobalApiInterceptorFlow {
     this.notes.enterAccountNote(noteText);
     this.notes.save();
     this.actions.waitForAddNoteNonRetriablePermissionError(statusCode);
+    cy.location('pathname', this.common.getTimeoutOptions()).should('eq', '/error/permission-denied');
     this.common.assertHeaderContains(expectedHeader);
   }
 

--- a/cypress/support/step_definitions/global-api-interceptor.steps.ts
+++ b/cypress/support/step_definitions/global-api-interceptor.steps.ts
@@ -80,6 +80,14 @@ When(
   },
 );
 
+When(
+  'I save account note {string} and the Add Note request fails with a non-retriable {int} error',
+  (noteText: string, statusCode: number) => {
+    log('step', 'Saving account note with non-retriable Add Note error', { statusCode });
+    flow().saveAccountNoteWithNonRetriablePermissionError(noteText, statusCode);
+  },
+);
+
 Then('the global error banner is displayed', () => {
   log('assert', 'Asserting global error banner is visible');
   actions().assertGlobalErrorBanner();
@@ -98,4 +106,9 @@ Then('the global banner clears after refresh on the {string} page', (expectedHea
 Then('the error page shows:', (table: DataTable) => {
   log('assert', 'Asserting error page content', { rows: table.raw() });
   actions().assertErrorPageContent(table);
+});
+
+Then('the permission denied Go back link returns me to the Add account note screen', () => {
+  log('assert', 'Returning from Permission Denied page to Add account note screen');
+  flow().returnToAddAccountNoteFromPermissionDenied();
 });

--- a/cypress/support/step_definitions/global-api-interceptor.steps.ts
+++ b/cypress/support/step_definitions/global-api-interceptor.steps.ts
@@ -107,8 +107,3 @@ Then('the error page shows:', (table: DataTable) => {
   log('assert', 'Asserting error page content', { rows: table.raw() });
   actions().assertErrorPageContent(table);
 });
-
-Then('the permission denied Go back link returns me to the Add account note screen', () => {
-  log('assert', 'Returning from Permission Denied page to Add account note screen');
-  flow().returnToAddAccountNoteFromPermissionDenied();
-});


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/PO-2227


### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done
The scenario verifies:
- an account note save triggers the Add Note POST endpoint
- the endpoint is stubbed with a non-retriable 403 response
- the Permission Denied page is displayed with the expected content
- the page includes the expected Go back behaviour from the design/AC



### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
