### PR TITLE
Update nightly demo legacy checks for DEV gateway and demo LaunchDarkly

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -28,12 +28,12 @@ properties([
     booleanParam(
       name: 'RunUatTech',
       defaultValue: false,
-      description: 'Run UAT-Technical stage (demo -> pre-prod legacy checks)'
+      description: 'Run UAT-Technical stage (demo -> selected legacy checks)'
     ),
     booleanParam(
       name: 'RunR1aOffLegacyDemo',
       defaultValue: false,
-      description: 'Run R1A Off legacy demo stage (demo -> pre-prod legacy checks)'
+      description: 'Run R1A Off legacy demo stage (demo -> selected legacy checks)'
     ),
     booleanParam(name: 'ZephyrExecution', defaultValue: false, description: 'Create Zephyr Execution'),
     choice(
@@ -66,7 +66,7 @@ String failureResult = 'FAILURE'
 @Field String legacyGatewayUrlPreProd = 'https://cloudgobgateway.test.platform.hmcts.net/opal'
 @Field String legacyGatewayUrlDev = 'https://opal-legacy-db-stub.staging.platform.hmcts.net/opal'
 @Field String launchDarklyApiVersion = '20240415'
-@Field String launchDarklyEnvironmentKey = 'test'
+@Field String launchDarklyEnvironmentKey = 'demo'
 @Field String launchDarklyFlagKey = 'app-mode'
 @Field String launchDarklyOpalVariationName = opalName
 @Field String launchDarklyLegacyVariationName = 'legacy'
@@ -203,8 +203,18 @@ INSTALL ${browser.toUpperCase()} OR DISABLE THE ${browser.toUpperCase()} RUN
   return browser
 }
 
-// Archive pipeline artifacts without failing when none are present.
+// Check whether any files in the workspace match the provided glob.
+boolean hasMatchingFiles(String glob) {
+  return findFiles(glob: glob).length > zeroIndex
+}
+
+// Archive pipeline artifacts only when the expected files are present.
 void archiveArtifact(String path) {
+  if (!hasMatchingFiles(path)) {
+    echo "Skipping artifact archive for '${path}' because no matching files were created."
+    return
+  }
+
   archiveArtifacts artifacts: path, allowEmptyArchive: true
 }
 
@@ -214,13 +224,26 @@ void archiveZephyrReports(String outputDir) {
   archiveArtifact("${outputDir}/zephyr/cypress-report-1.json")
 }
 
-// Publish an HTML report directory with Jenkins HTML Publisher.
+// Publish an HTML report directory with Jenkins HTML Publisher when the report exists.
 void publishHtmlReport(String dir, String files, String name) {
+  String normalizedDir = dir.endsWith('/') ? dir[zeroIndex..-2] : dir
+  String reportGlob = "${normalizedDir}/${files}"
+
+  if (!fileExists(normalizedDir)) {
+    echo "Skipping HTML report '${name}' because directory '${normalizedDir}' was not created."
+    return
+  }
+
+  if (!hasMatchingFiles(reportGlob)) {
+    echo "Skipping HTML report '${name}' because report files matching '${reportGlob}' were not created."
+    return
+  }
+
   publishHTML target: [
     allowMissing         : true,
     alwaysLinkToLastBuild: true,
     keepAll              : true,
-    reportDir            : dir,
+    reportDir            : normalizedDir,
     reportFiles          : files,
     reportName           : name
   ]
@@ -318,8 +341,18 @@ String getLegacyHealthCheckStatus() {
   ).trim()
 }
 
+// Run the legacy gateway health check only when the selected gateway supports it.
+boolean shouldRunLegacyHealthCheck() {
+  return params.LEGACY_URL == legacyUrlPreProdChoice
+}
+
 // Wait until the legacy health endpoint responds successfully after toggling app mode.
 void waitForLegacyHealthCheck() {
+  if (!shouldRunLegacyHealthCheck()) {
+    echo "Skipping legacy health check because LEGACY_URL=${params.LEGACY_URL} uses the DEV stub."
+    return
+  }
+
   timeout(time: uatHealthCheckTimeoutMinutes, unit: 'MINUTES') {
     script {
       boolean healthy = false

--- a/README.md
+++ b/README.md
@@ -424,7 +424,8 @@ The nightly Jenkins pipeline runs its stages in this order after checkout and te
 Notes for the nightly pipeline:
 
 - `LEGACY_URL` currently defaults to `DEV` so the demo legacy stages can run while `PRE-PROD` is not ready.
-- `LEGACY_URL=PRE-PROD` points the legacy gateway checks at `https://cloudgobgateway.test.platform.hmcts.net/opal`. `LEGACY_URL=DEV` uses the staging legacy DB stub instead.
+- `LEGACY_URL=PRE-PROD` points the legacy gateway checks at `https://cloudgobgateway.test.platform.hmcts.net/opal`.
+- `LEGACY_URL=DEV` uses the staging legacy DB stub and skips the pre-prod `getGmasTest` health check.
 - `ZephyrExecution=true`, or a Friday nightly run, enables the Zephyr reporting flow for the normal component and functional paths.
 
 ### Debugging

--- a/cypress/e2e/functional/opal/features/manualAccountCreation/checkAndValidateDraftAccounts/checkAndValidateDraftAccountsJourneys.feature
+++ b/cypress/e2e/functional/opal/features/manualAccountCreation/checkAndValidateDraftAccounts/checkAndValidateDraftAccountsJourneys.feature
@@ -18,58 +18,50 @@ Feature: Check and Validate Draft Accounts - E2E Technical Scenarios
       | Decision | Approve |
     Then I should see the checker header "Review accounts" and status heading "To review"
     And the draft success banner is "<banner>"
-    @skip @JIRA-IGNORE
+    @UAT-Technical @JIRA-NFR:PO-2506
     Examples: Adult
       | scenario            | draftType      | identifierField           | identifierValue        | listName                                  | header                                      | banner                                                               |
       | E2E auto test Adult | opalE2EAdultEn | account.defendant.surname | OPAL E TO E{uniqUpper} | OPAL E TO E{uniqUpper}, Opal Scenario one | Mr Opal Scenario one OPAL E TO E{uniqUpper} | You have approved Opal Scenario one OPAL E TO E{uniqUpper}'s account |
 
-    @skip @JIRA-IGNORE
+    @UAT-Technical @JIRA-NFR:PO-2506
     Examples: Adult, Welsh
       | scenario                   | draftType      | identifierField           | identifierValue        | listName                                  | header                                      | banner                                                               |
       | E2E auto test Adult, Welsh | opalE2EAdultCy | account.defendant.surname | OPAL E TO E{uniqUpper} | OPAL E TO E{uniqUpper}, Opal Scenario two | Mr Opal Scenario two OPAL E TO E{uniqUpper} | You have approved Opal Scenario two OPAL E TO E{uniqUpper}'s account |
-
 
     @UAT-Technical @JIRA-NFR:PO-2506
     Examples: Parent/Guardian, Adult Major
       | scenario                             | draftType           | identifierField           | identifierValue        | listName                                    | header                                          | banner                                                                 |
       | E2E auto test Adult, with PG (Major) | opalE2EAdultPgMajor | account.defendant.surname | OPAL E TO E{uniqUpper} | OPAL E TO E{uniqUpper}, Opal Scenario three | Miss Opal Scenario three OPAL E TO E{uniqUpper} | You have approved Opal Scenario three OPAL E TO E{uniqUpper}'s account |
 
-
     @UAT-Technical @JIRA-NFR:PO-2506
     Examples: Parent/Guardian, Adult Minor
       | scenario                             | draftType           | identifierField           | identifierValue        | listName                                   | header                                         | banner                                                                |
       | E2E auto test Adult, with PG (Minor) | opalE2EAdultPgMinor | account.defendant.surname | OPAL E TO E{uniqUpper} | OPAL E TO E{uniqUpper}, Opal Scenario four | Miss Opal Scenario four OPAL E TO E{uniqUpper} | You have approved Opal Scenario four OPAL E TO E{uniqUpper}'s account |
-
 
     @UAT-Technical @JIRA-NFR:PO-2506
     Examples: Parent/Guardian, Youth to pay
       | scenario                       | draftType         | identifierField           | identifierValue        | listName                                   | header                                       | banner                                                                |
       | E2E auto test Youth, PG to pay | opalE2EYouthPgPay | account.defendant.surname | OPAL E TO E{uniqUpper} | OPAL E TO E{uniqUpper}, Opal Scenario five | Ms Opal Scenario five OPAL E TO E{uniqUpper} | You have approved Opal Scenario five OPAL E TO E{uniqUpper}'s account |
 
-
     @UAT-Technical @JIRA-NFR:PO-2506
     Examples: Youth
       | scenario                 | draftType        | identifierField           | identifierValue        | listName                                  | header                                      | banner                                                               |
       | E2E auto test Youth only | opalE2EYouthOnly | account.defendant.surname | OPAL E TO E{uniqUpper} | OPAL E TO E{uniqUpper}, Opal Scenario six | Mr Opal Scenario six OPAL E TO E{uniqUpper} | You have approved Opal Scenario six OPAL E TO E{uniqUpper}'s account |
-
 
     @UAT-Technical @JIRA-NFR:PO-2506
     Examples: Company
       | scenario              | draftType      | identifierField                | identifierValue                    | listName                           | header                             | banner                                                         |
       | E2E auto test Company | opalE2ECompany | account.defendant.company_name | OPAL E TO E S SCENARIO SEVEN{uniq} | OPAL E TO E S SCENARIO SEVEN{uniq} | OPAL E TO E S SCENARIO SEVEN{uniq} | You have approved OPAL E TO E S SCENARIO SEVEN{uniq}'s account |
 
-
     @UAT-Technical @JIRA-NFR:PO-2506
     Examples: Fixed Penalty Adult (Vehicle)
       | scenario                      | draftType                | identifierField           | identifierValue        | listName                                    | header                                        | banner                                                                 |
       | Fixed Penalty Adult (Vehicle) | opalE2EFixedPenaltyAdult | account.defendant.surname | OPAL E TO E{uniqUpper} | OPAL E TO E{uniqUpper}, Opal Scenario eight | Mr Opal Scenario eight OPAL E TO E{uniqUpper} | You have approved Opal Scenario eight OPAL E TO E{uniqUpper}'s account |
 
-
     @UAT-Technical @JIRA-NFR:PO-2506
     Examples: Fixed Penalty Youth (Non-Vehicle)
       | scenario                          | draftType                | identifierField           | identifierValue        | listName                                   | header                                       | banner                                                                |
       | Fixed Penalty Youth (Non-Vehicle) | opalE2EFixedPenaltyYouth | account.defendant.surname | OPAL E TO E{uniqUpper} | OPAL E TO E{uniqUpper}, Opal Scenario nine | Mr Opal Scenario nine OPAL E TO E{uniqUpper} | You have approved Opal Scenario nine OPAL E TO E{uniqUpper}'s account |
-
 
     @UAT-Technical @JIRA-NFR:PO-2506
     Examples: Fixed Penalty Company (Vehicle)


### PR DESCRIPTION
### Jira link

N/A

### Change description

- update the nightly Jenkins pipeline so demo legacy stages skip the legacy gateway health check when LEGACY_URL=DEV
- keep the existing health check for LEGACY_URL=PRE-PROD
- switch the LaunchDarkly environment used by the demo legacy stages from test to demo
- guard artifact archiving and HTML report publishing so missing outputs are logged clearly instead of producing noisy Jenkins errors
- update the nightly pipeline documentation to reflect the new LEGACY_URL behaviour
- Removed out comments on a couple of UAT technical tests

### Testing done

Run pipeline

### Security Vulnerability Assessment ###

N/A

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ x] commit messages are meaningful and follow good commit message guidelines
- [ x] README and other documentation has been updated / added (if needed)
- [ x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
