### PR TITLE
Update nightly LEGACY_URL default to PRE-PROD

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -38,8 +38,8 @@ properties([
     booleanParam(name: 'ZephyrExecution', defaultValue: false, description: 'Create Zephyr Execution'),
     choice(
       name: 'LEGACY_URL',
-      choices: [legacyUrlDevChoice, legacyUrlPreProdChoice],
-      description: 'Determines the URL to use for legacy tests. Default is DEV until PRE-PROD is ready.'
+      choices: [legacyUrlPreProdChoice, legacyUrlDevChoice],
+      description: 'Determines the URL to use for legacy tests. Default is PRE-PROD.'
     ),
   ])
 ])

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ The nightly Jenkins pipeline runs its stages in this order after checkout and te
 
 Notes for the nightly pipeline:
 
-- `LEGACY_URL` currently defaults to `DEV` so the demo legacy stages can run while `PRE-PROD` is not ready.
+- `LEGACY_URL` defaults to `PRE-PROD`.
 - `LEGACY_URL=PRE-PROD` points the legacy gateway checks at `https://cloudgobgateway.test.platform.hmcts.net/opal`.
 - `LEGACY_URL=DEV` uses the staging legacy DB stub and skips the pre-prod `getGmasTest` health check.
 - `ZephyrExecution=true`, or a Friday nightly run, enables the Zephyr reporting flow for the normal component and functional paths.


### PR DESCRIPTION
### Jira link

N/A

### Change description

Updates the nightly pipeline so LEGACY_URL now defaults to PRE-PROD, reflecting that pre-prod is ready. Also updates the README to remove the old note that said the default remained DEV.

Changes

- Reordered LEGACY_URL choices in Jenkinsfile_nightly so PRE-PROD is the default selected value
- Updated the Jenkins parameter description to state the default is PRE-PROD
- Updated the README nightly pipeline notes to match the new default
- Kept the DEV option documented as a fallback that uses the staging legacy DB stub and skips the pre-prod health check

### Testing done

Not run, as this is a pipeline configuration and documentation change only

### Security Vulnerability Assessment ###

N/A

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ x] commit messages are meaningful and follow good commit message guidelines
- [ x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
