### PR TITLE
Fix nightly legacy demo report publishing on failure and restrict account evidence archiving to UAT-Technical

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -462,6 +462,7 @@ void runDemoLegacyStage(Map<String, Object> stageConfig, Closure runCommand) {
   String outputDirName = stageConfig.outputDirName as String
   String reportName = stageConfig.reportName as String
   String browserToRun = stageConfig.browserToRun as String
+  boolean archiveAccountEvidence = (stageConfig.archiveAccountEvidence ?: false) as boolean
   List<String> extraEnv = (stageConfig.extraEnv ?: []) as List<String>
   String reportFilePrefix = outputDirName
 
@@ -492,12 +493,13 @@ void runDemoLegacyStage(Map<String, Object> stageConfig, Closure runCommand) {
       withEnv(stageEnv) {
         runCommand.call()
       }
-
-      prepareLegacyDemoArtifacts(browserToRun, outputDirName, reportFilePrefix)
     } finally {
+      prepareLegacyDemoArtifacts(browserToRun, outputDirName, reportFilePrefix)
       archiveArtifact(functionalProdArtifactsPath)
-      archiveArtifact('functional-output/account_evidence/created-accounts.json')
-      archiveArtifact('functional-output/account_evidence/**')
+      if (archiveAccountEvidence) {
+        archiveArtifact('functional-output/account_evidence/created-accounts.json')
+        archiveArtifact('functional-output/account_evidence/**')
+      }
       archiveArtifact("functional-output/screenshots/${browserToRun}/**")
       archiveArtifact("functional-output/prod/${browserToRun}/${outputDirName}/**")
       publishHtmlReport(
@@ -563,6 +565,7 @@ void runUatTechnicalStage(
     outputDirName     : demoStageUatTechnicalDirName,
     reportName        : "UAT-Technical Functional Test Report (${browserToRun})",
     browserToRun      : browserToRun,
+    archiveAccountEvidence: true,
   ]) {
     sh "node scripts/run-yarn-sequence.js ${uatCommand}"
   }


### PR DESCRIPTION
### Jira link

N/A

### Change description

This PR fixes nightly legacy demo report handling so Jenkins still prepares and publishes the stage-specific cucumber HTML report when a demo stage fails. It also limits account-evidence archiving to the UAT-Technical stage only.

Changes

Move legacy demo artifact preparation into finally in runDemoLegacyStage(...)
Ensure RunR1aLegacyDemo and RunR1aOffLegacyDemo still prepare the renamed stage report on failure
Ensure any generated cucumber-report.json is still copied into the stage artifact folder during failure handling
Restrict created-accounts.json and functional-output/account_evidence/** archiving to UAT-Technical only
Why

Previously, demo-stage artifact preparation only ran after a successful test command
If RunR1aLegacyDemo or RunR1aOffLegacyDemo failed, Jenkins could still archive the raw edge-report.html, but the stage-specific report was never prepared, so no left-nav HTML report was published
Account evidence was being archived for all demo legacy stages, although it is only needed for UAT-Technical
Expected outcome

Failed RunR1aLegacyDemo and RunR1aOffLegacyDemo runs still publish their stage-specific HTML report in Jenkins when the raw report exists
Demo legacy stages no longer archive account-evidence artifacts unless the run is UAT-Technical

### Testing done

N/A

### Security Vulnerability Assessment ###

N/A

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
