### PR TITLE
Updates to flags on tests that are only required when feature flags are off

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -23,7 +23,7 @@ properties([
     booleanParam(
       name: 'Functional',
       defaultValue: true,
-      description: 'Run functional tests excluding R1AOff and R1BOff'
+      description: 'Run functional tests excluding R1AOff, R1BOff, R1CWriteOffOff and R1CEnforcementOperationalReportingOff'
     ),
     booleanParam(name: 'Legacy', defaultValue: false, description: 'Run legacy tests'),
     booleanParam(name: 'RunChrome', defaultValue: false, description: 'Run Chrome tests'),

--- a/cypress/e2e/functional/opal/features/consolidation/release1c/WriteOffRelease1cFeatureToggles.feature
+++ b/cypress/e2e/functional/opal/features/consolidation/release1c/WriteOffRelease1cFeatureToggles.feature
@@ -7,14 +7,14 @@ Feature: Write Off Release 1C Feature Toggles
     When I navigate directly to the Consolidate accounts page
     Then I should see the header containing text "Consolidate accounts"
 
-  @R1CWriteOffOff @JIRA-STORY:PO-3757 @JIRA-EPIC:PO-3685
+  @R1CWriteOffOff @FeatureFlag @JIRA-STORY:PO-3757 @JIRA-EPIC:PO-3685
   Scenario: Consolidate accounts entry point is hidden from the Accounts dashboard when release 1c write off is disabled
     Given I am logged in with email "opal-test@dev.platform.hmcts.net"
     When I select the Fines primary navigation item "Accounts"
     Then I am taken to the "Accounts" Fines landing page
     And I should not see the Consolidate accounts link on the Accounts dashboard
 
-  @R1CWriteOffOff @JIRA-STORY:PO-3757 @JIRA-EPIC:PO-3685
+  @R1CWriteOffOff @FeatureFlag @JIRA-STORY:PO-3757 @JIRA-EPIC:PO-3685
   Scenario: Consolidate accounts is unavailable through direct navigation when release 1c write off is disabled
     Given I am authenticated with email "opal-test@dev.platform.hmcts.net"
     When I navigate directly to the Consolidate accounts page

--- a/cypress/e2e/functional/opal/features/fineAccountEnquiry/release1b/AccountEnquiryRelease1bFeatureToggles.feature
+++ b/cypress/e2e/functional/opal/features/fineAccountEnquiry/release1b/AccountEnquiryRelease1bFeatureToggles.feature
@@ -1,20 +1,20 @@
 @JIRA-LABEL:account-enquiry
 Feature: Account Enquiry Release 1B Feature Toggles
 
-  @R1BOff @JIRA-STORY:PO-3720 @JIRA-EPIC:PO-3685
+  @R1BOff @FeatureFlag @JIRA-STORY:PO-3720 @JIRA-EPIC:PO-3685
   Scenario: Accounts is the default landing page when release 1b is disabled
     Given I am authenticated with email "opal-test@dev.platform.hmcts.net"
     Then I am taken to the "Accounts" Fines landing page
     And I should not see the Fines primary navigation item "Search"
 
-  @R1BOff @JIRA-STORY:PO-3720 @JIRA-EPIC:PO-3685
+  @R1BOff @FeatureFlag @JIRA-STORY:PO-3720 @JIRA-EPIC:PO-3685
   Scenario: Direct navigation to Account Search is blocked when release 1b is disabled
     Given I am authenticated with email "opal-test@dev.platform.hmcts.net"
     When I navigate directly to the Account Search page
     Then I should see an Access Denied page
     And I should see a "Back to dashboard" action
 
-  @R1BOff @JIRA-STORY:PO-3720 @JIRA-EPIC:PO-3685
+  @R1BOff @FeatureFlag @JIRA-STORY:PO-3720 @JIRA-EPIC:PO-3685
   Scenario: Direct navigation to Account Enquiry is blocked when release 1b is disabled
     Given I am authenticated with email "opal-test@dev.platform.hmcts.net"
     And a published adult or youth defendant account exists:
@@ -26,7 +26,7 @@ Feature: Account Enquiry Release 1B Feature Toggles
     Then I should see an Access Denied page
     And I should see a "Back to dashboard" action
 
-  @R1B @R1CWriteOffOff @JIRA-STORY:PO-3720 @JIRA-STORY:PO-3757 @JIRA-EPIC:PO-3685
+  @R1B @R1CWriteOffOff @FeatureFlag @JIRA-STORY:PO-3720 @JIRA-STORY:PO-3757 @JIRA-EPIC:PO-3685
   Scenario: Impositions write off actions are hidden when release 1c write off is disabled
     Given I am logged in with email "opal-test@dev.platform.hmcts.net"
     And a published adult or youth defendant account exists:

--- a/cypress/e2e/functional/opal/features/fineAccountEnquiry/release1b/SearchAndMatchesRelease1bFeatureToggles.feature
+++ b/cypress/e2e/functional/opal/features/fineAccountEnquiry/release1b/SearchAndMatchesRelease1bFeatureToggles.feature
@@ -16,7 +16,7 @@ Feature: Search and Matches Release 1B Feature Toggles
     When I open the latest matching result from the search results
     Then I should see the account summary header contains "RELEASE1BSEARCH{uniqUpper}"
 
-  @R1BOff @JIRA-STORY:PO-3720 @JIRA-EPIC:PO-3685
+  @R1BOff @FeatureFlag @JIRA-STORY:PO-3720 @JIRA-EPIC:PO-3685
   Scenario: Search and Matches is hidden when release 1b is disabled
     Given I am authenticated with email "opal-test@dev.platform.hmcts.net"
     Then I should not see the Fines primary navigation item "Search"

--- a/cypress/e2e/functional/opal/features/manualAccountCreation/release1a/DraftAccountsRelease1aFeatureToggles.feature
+++ b/cypress/e2e/functional/opal/features/manualAccountCreation/release1a/DraftAccountsRelease1aFeatureToggles.feature
@@ -22,20 +22,20 @@ Feature: Draft Accounts Release 1A Feature Toggles
       | entryPoint                        | header          |
       | Check and Validate Draft Accounts | Review accounts |
 
-  @R1AOff @JIRA-STORY:PO-3719 @JIRA-EPIC:PO-3685
+  @R1AOff @FeatureFlag @JIRA-STORY:PO-3719 @JIRA-EPIC:PO-3685
   Scenario: Access denied is shown after sign in when release 1a is disabled
     Given I am authenticated with email "opal-test@dev.platform.hmcts.net"
     Then I should see an Access Denied page
     And I do not see the Fines primary navigation
 
-  @R1AOff @JIRA-STORY:PO-3719 @JIRA-EPIC:PO-3685
+  @R1AOff @FeatureFlag @JIRA-STORY:PO-3719 @JIRA-EPIC:PO-3685
   Scenario: Direct navigation to the Accounts dashboard is blocked when release 1a is disabled
     Given I am authenticated with email "opal-test@dev.platform.hmcts.net"
     When I navigate directly to the Accounts dashboard
     Then I should see an Access Denied page
     And I should see a "Back to dashboard" action
 
-  @R1AOff @JIRA-STORY:PO-3719 @JIRA-EPIC:PO-3685
+  @R1AOff @FeatureFlag @JIRA-STORY:PO-3719 @JIRA-EPIC:PO-3685
   Scenario Outline: Direct navigation to <entryPoint> is blocked when release 1a is disabled
     Given I am authenticated with email "opal-test@dev.platform.hmcts.net"
     When I navigate directly to the Accounts dashboard entry point "<entryPoint>"
@@ -47,7 +47,7 @@ Feature: Draft Accounts Release 1A Feature Toggles
       | Create and Manage Draft Accounts  |
       | Check and Validate Draft Accounts |
 
-  @R1BOff @JIRA-STORY:PO-3719 @JIRA-STORY:PO-3720 @JIRA-EPIC:PO-3685
+  @R1BOff @FeatureFlag @JIRA-STORY:PO-3719 @JIRA-STORY:PO-3720 @JIRA-EPIC:PO-3685
   Scenario: Approved account numbers are shown as plain text when release 1b is disabled
     Given I clear all approved accounts
     And I create a "company" approved account with the following details:

--- a/cypress/e2e/functional/opal/features/navigation/finesPrimaryNavigation.feature
+++ b/cypress/e2e/functional/opal/features/navigation/finesPrimaryNavigation.feature
@@ -13,7 +13,7 @@ Feature: Fines primary navigation
     Then I see the Fines primary navigation with Search selected by default
     When I open Search for an Account
 
-  @JIRA-STORY:PO-3720 @JIRA-EPIC:PO-3685 @R1BOff
+  @JIRA-STORY:PO-3720 @JIRA-EPIC:PO-3685 @R1BOff @FeatureFlag
   Scenario: Search is hidden as the landing page after login when release 1b is disabled
     Given I am authenticated with email "opal-test@dev.platform.hmcts.net"
     Then I should not see the Fines primary navigation item "Search"

--- a/cypress/e2e/functional/opal/features/navigation/release1c/ReportsRelease1cEnforcementOperationalReportingFeatureToggles.feature
+++ b/cypress/e2e/functional/opal/features/navigation/release1c/ReportsRelease1cEnforcementOperationalReportingFeatureToggles.feature
@@ -10,12 +10,12 @@ Feature: Reports Release 1C Enforcement Operational Reporting Feature Toggles
     When I open Your reports from the Reports landing page
     Then I am taken to the Your reports summary list screen
 
-  @R1CEnforcementOperationalReportingOff @JIRA-STORY:PO-3758 @JIRA-EPIC:PO-3685
+  @R1CEnforcementOperationalReportingOff @FeatureFlag @JIRA-STORY:PO-3758 @JIRA-EPIC:PO-3685
   Scenario: Reports is hidden from the primary navigation when release 1c enforcement operational reporting is disabled
     Given I am logged in with email "opal-test@dev.platform.hmcts.net"
     Then I should not see the Fines primary navigation item "Reports"
 
-  @R1CEnforcementOperationalReportingOff @JIRA-STORY:PO-3758 @JIRA-EPIC:PO-3685
+  @R1CEnforcementOperationalReportingOff @FeatureFlag @JIRA-STORY:PO-3758 @JIRA-EPIC:PO-3685
   Scenario Outline: Direct navigation to <entryPoint> is blocked when release 1c enforcement operational reporting is disabled
     Given I am authenticated with email "opal-test@dev.platform.hmcts.net"
     When I navigate directly to the Reports entry point "<entryPoint>"


### PR DESCRIPTION
### Jira link

N/A

### Change description

Marks the release-toggle E2E scenarios with @FeatureFlag so they are excluded from the default test:functional nightly run. This removes the need for a separate nightly-specific functional command and prevents R1AOff, R1BOff, R1CWriteOffOff, and R1CEnforcementOperationalReportingOff scenarios from running by default.

### Testing done

N/A

### Security Vulnerability Assessment ###

N/A

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
