### PR TITLE
Fix nightly R1A/UAT demo reports by clearing shared functional-output before each demo legacy stage

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -524,6 +524,9 @@ void runDemoLegacyStage(Map<String, Object> stageConfig, Closure runCommand) {
       }
       waitForLegacyHealthCheck()
       sh 'echo "Waiting 30s for system warmup..." ; sleep 30'
+      // Demo legacy stages publish from the shared functional output directory.
+      // Reset it first so each stage report contains only the stage that just ran.
+      sh "rm -rf ${functionalOutputRoot}"
 
       withEnv(stageEnv) {
         runCommand.call()


### PR DESCRIPTION
### Jira link

N/A

### Change description

The nightly R1A Legacy Demo, R1A Off Legacy Demo, and UAT-Technical stages publish reports by copying artifacts from the shared functional-output/prod/<browser>/cucumber directory. When that directory already contains results from an earlier functional stage, the demo-stage report can appear oversized or mixed, making it difficult to see the real failures for that stage.

Change
Added a reset of functional-output in the shared runDemoLegacyStage helper before the demo legacy test command runs.

### Testing done

N/A

### Security Vulnerability Assessment ###

N/A

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
