### PR TITLE
Altered logic so that a chosen stage will run in the browser selected.

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -26,8 +26,16 @@ properties([
       description: 'Run functional tests excluding feature-flag off scenarios'
     ),
     booleanParam(name: 'Legacy', defaultValue: false, description: 'Run legacy tests'),
-    booleanParam(name: 'RunChrome', defaultValue: false, description: 'Run Chrome tests'),
-    booleanParam(name: 'RunFirefox', defaultValue: false, description: 'Run Firefox tests'),
+    booleanParam(
+      name: 'RunChrome',
+      defaultValue: false,
+      description: 'Run the selected nightly test stages in Chrome instead of the default browser'
+    ),
+    booleanParam(
+      name: 'RunFirefox',
+      defaultValue: false,
+      description: 'Run the selected nightly test stages in Firefox instead of the default browser'
+    ),
     booleanParam(
       name: 'RunR1aLegacyDemo',
       defaultValue: true,
@@ -197,6 +205,28 @@ INSTALL A SUPPORTED BROWSER OR SET BROWSER_TO_RUN EXPLICITLY
   }
 
   return normalizedBrowser
+}
+
+// Resolve the single browser that the selected nightly stages should use.
+String resolveSelectedNightlyBrowser() {
+  if (params.RunChrome && params.RunFirefox) {
+    error '''\
+========================================================================
+RUNCHROME AND RUNFIREFOX CANNOT BOTH BE ENABLED
+SELECT A SINGLE BROWSER OVERRIDE OR USE THE DEFAULT EDGE MODE
+========================================================================
+'''.stripIndent()
+  }
+
+  if (params.RunChrome) {
+    return requireInstalledBrowser(browserChrome)
+  }
+
+  if (params.RunFirefox) {
+    return requireInstalledBrowser(browserFirefox)
+  }
+
+  return resolvePipelineBrowser(env.BROWSER_TO_RUN ?: browserEdge)
 }
 
 // Require an explicitly requested browser to be present before running its stage.
@@ -744,29 +774,6 @@ void runLegacyStage(
   }
 }
 
-// Run an explicit browser stage using the provided command and report metadata.
-void runBrowserStage(
-  boolean enabled,
-  String failureResultValue,
-  String failureMessage,
-  uk.gov.hmcts.contino.YarnBuilder builder,
-  Map<String, String> stageConfig
-) {
-  runNightlyStage(enabled, stageConfig.stageName, failureResultValue, failureMessage) {
-    try {
-      builder.yarn(stageConfig.yarnCommand)
-    } finally {
-      archiveArtifact("${functionalOutputRoot}/prod/${stageConfig.browserToRun}/**")
-      archiveArtifact("${functionalOutputRoot}/screenshots/${stageConfig.browserToRun}/**")
-      publishHtmlReport(
-        "${functionalOutputRoot}/prod/${stageConfig.browserToRun}/cucumber/",
-        "${stageConfig.browserToRun}-report.html",
-        "${stageConfig.browserToRun.capitalize()} Functional Test Report"
-      )
-    }
-  }
-}
-
 // Restore cached parallel weight files from the previous successful nightly run.
 void performArtifactOperations() {
   sh 'mkdir -p cypress/parallel/weights/pipeline'
@@ -857,7 +864,7 @@ withNightlyPipeline(type, product, component) {
     if (!isBrowserInstalled(browserFirefox)) {
       echoBrowserMissingBanner(browserFirefox)
     }
-    env.BROWSER_TO_RUN = resolvePipelineBrowser(env.BROWSER_TO_RUN ?: browserEdge)
+    env.BROWSER_TO_RUN = resolveSelectedNightlyBrowser()
     echo "Using browser for this pipeline run: ${env.BROWSER_TO_RUN}"
     performArtifactOperations()
     setupTestSpecifications()
@@ -865,8 +872,6 @@ withNightlyPipeline(type, product, component) {
 
   afterAlways('DependencyCheckNightly') {
     String browserToRun = env.BROWSER_TO_RUN
-    String chromeBrowserToRun = params.RunChrome ? requireInstalledBrowser(browserChrome) : browserChrome
-    String firefoxBrowserToRun = params.RunFirefox ? requireInstalledBrowser(browserFirefox) : browserFirefox
     echo 'Component:' + params.Component
     echo 'Smoke:' + params.Smoke
     echo 'Functional:' + params.Functional
@@ -927,27 +932,5 @@ Description: ${env.EXECUTION_CYCLE_DESCRIPTION}
     )
     runUatTechnicalStage(params.RunUatTech, failureResult, shouldRunWithZephyr, browserToRun)
     runLegacyStage(params.Legacy, failureResult, yarnBuilder, shouldRunWithZephyr, browserToRun)
-    runBrowserStage(
-      params.RunChrome,
-      failureResult,
-      'Chrome tests failed',
-      yarnBuilder,
-      [
-        stageName   : 'Chrome Tests',
-        yarnCommand : 'test:Chrome',
-        browserToRun: chromeBrowserToRun,
-      ]
-    )
-    runBrowserStage(
-      params.RunFirefox,
-      failureResult,
-      'Firefox tests failed',
-      yarnBuilder,
-      [
-        stageName   : 'Firefox Tests',
-        yarnCommand : 'test:Firefox',
-        browserToRun: firefoxBrowserToRun,
-      ]
-    )
   }
 }

--- a/README.md
+++ b/README.md
@@ -419,11 +419,13 @@ The nightly Jenkins pipeline runs its stages in this order after checkout and te
 - `R1A Off Legacy Demo` runs only when `RunR1aOffLegacyDemo=true`. It uses the same demo legacy flow and runs `yarn test:functional:r1a_off`.
 - `UAT-Technical` runs only when `RunUatTech=true`. It uses the same demo legacy flow and runs `yarn test:functional:uat_legacy`.
 - `Legacy Tests` runs only when `Legacy=true`. It runs the general functional suite in legacy mode.
-- `Chrome Tests` runs only when `RunChrome=true`. It reruns the functional suite in Chrome.
-- `Firefox Tests` runs only when `RunFirefox=true`. It reruns the functional suite in Firefox.
+- `RunChrome=true` switches the selected nightly stages to Chrome instead of the default browser.
+- `RunFirefox=true` switches the selected nightly stages to Firefox instead of the default browser.
 
 Notes for the nightly pipeline:
 
+- The nightly pipeline uses Edge by default. If Edge is unavailable on the Jenkins agent, it falls back to Chrome.
+- `RunChrome` and `RunFirefox` are mutually exclusive browser overrides for the selected stages.
 - `LEGACY_URL` defaults to `PRE-PROD`.
 - `LEGACY_URL=PRE-PROD` points the legacy gateway checks at `https://cloudgobgateway.test.platform.hmcts.net/opal`.
 - `LEGACY_URL=DEV` uses the staging legacy DB stub, skips the pre-prod `getGmasTest` health check, and does not patch the demo `app-mode` LaunchDarkly flag to `legacy`.

--- a/README.md
+++ b/README.md
@@ -426,6 +426,8 @@ Notes for the nightly pipeline:
 
 - The nightly pipeline uses Edge by default. If Edge is unavailable on the Jenkins agent, it falls back to Chrome.
 - `RunChrome` and `RunFirefox` are mutually exclusive browser overrides for the selected stages.
+- Selecting `RunChrome` or `RunFirefox` does not add any extra test stages. It only changes the browser used by the stages enabled for that run.
+- If no other parameters are changed, the default-enabled nightly stages still run, using the selected browser override when one is set.
 - `LEGACY_URL` defaults to `PRE-PROD`.
 - `LEGACY_URL=PRE-PROD` points the legacy gateway checks at `https://cloudgobgateway.test.platform.hmcts.net/opal`.
 - `LEGACY_URL=DEV` uses the staging legacy DB stub, skips the pre-prod `getGmasTest` health check, and does not patch the demo `app-mode` LaunchDarkly flag to `legacy`.


### PR DESCRIPTION
### Jira link

N/A

### Change description

This change updates the nightly Jenkins pipeline so browser selection applies to the chosen test stages instead of triggering separate browser-specific rerun stages.

RunChrome and RunFirefox now act as mutually exclusive browser overrides for the selected nightly stages, while Edge remains the default browser when neither option is selected. The pipeline resolves a single browser for the run up front, continues to fall back from Edge to Chrome when Edge is unavailable, and now fails fast if both browser overrides are enabled together. The README was also updated to reflect the new nightly browser-selection behavior.

### Testing done

N/A

### Security Vulnerability Assessment ###

N/A

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ x] commit messages are meaningful and follow good commit message guidelines
- [ x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
