### PR TITLE
PO-9047-make pagination accessible

### DIFF
--- a/src/app/flows/fines/components/abstract/abstract-sortable-table-pagination-accessibility/abstract-sortable-table-pagination-accessibility.component.spec.ts
+++ b/src/app/flows/fines/components/abstract/abstract-sortable-table-pagination-accessibility/abstract-sortable-table-pagination-accessibility.component.spec.ts
@@ -1,0 +1,61 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { UtilsService } from '@hmcts/opal-frontend-common/services/utils-service';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AbstractSortableTablePaginationAccessibilityComponent } from './abstract-sortable-table-pagination-accessibility.component';
+
+@Component({
+  standalone: true,
+  template: '<div id="pagination-top" tabindex="-1"></div>',
+})
+class TestPaginationAccessibilityComponent extends AbstractSortableTablePaginationAccessibilityComponent {
+  public readonly paginationTopElementId = 'pagination-top';
+}
+
+describe('AbstractSortableTablePaginationAccessibilityComponent', () => {
+  let component: TestPaginationAccessibilityComponent;
+  let fixture: ComponentFixture<TestPaginationAccessibilityComponent>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let utilsService: any;
+
+  beforeEach(async () => {
+    utilsService = {
+      scrollToTop: vi.fn().mockName('UtilsService.scrollToTop'),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [TestPaginationAccessibilityComponent],
+      providers: [{ provide: UtilsService, useValue: utilsService }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestPaginationAccessibilityComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should expose the current page status message', () => {
+    expect(component.paginationStatusMessageComputed()).toBe('Page 1 loaded');
+  });
+
+  it('should scroll to the top anchor and focus it when the page changes', () => {
+    component.displayTableDataSignal.set([{ id: 1 }, { id: 2 }] as never[]);
+    component.itemsPerPageSignal.set(1);
+    fixture.detectChanges();
+
+    const topAnchor = fixture.nativeElement.querySelector('#pagination-top') as HTMLDivElement | null;
+    expect(topAnchor).toBeTruthy();
+    if (!topAnchor) {
+      throw new Error('Top anchor not found');
+    }
+
+    const focusSpy = vi.spyOn(topAnchor, 'focus');
+
+    component.onPageChange(2);
+    fixture.detectChanges();
+
+    expect(component.currentPageSignal()).toBe(2);
+    expect(component.paginationStatusMessageComputed()).toBe('Page 2 loaded');
+    expect(utilsService.scrollToTop).toHaveBeenCalled();
+    expect(focusSpy).toHaveBeenCalled();
+  });
+});

--- a/src/app/flows/fines/components/abstract/abstract-sortable-table-pagination-accessibility/abstract-sortable-table-pagination-accessibility.component.ts
+++ b/src/app/flows/fines/components/abstract/abstract-sortable-table-pagination-accessibility/abstract-sortable-table-pagination-accessibility.component.ts
@@ -1,0 +1,18 @@
+import { DOCUMENT } from '@angular/common';
+import { computed, inject } from '@angular/core';
+import { AbstractSortableTablePaginationComponent } from '@hmcts/opal-frontend-common/components/abstract/abstract-sortable-table-pagination';
+import { UtilsService } from '@hmcts/opal-frontend-common/services/utils-service';
+
+export abstract class AbstractSortableTablePaginationAccessibilityComponent extends AbstractSortableTablePaginationComponent {
+  protected readonly utilsService = inject(UtilsService);
+  protected readonly document = inject(DOCUMENT);
+  public readonly paginationStatusMessageComputed = computed(() => `Page ${this.currentPageSignal()} loaded`);
+
+  public abstract readonly paginationTopElementId: string;
+
+  public override onPageChange(newPage: number): void {
+    super.onPageChange(newPage);
+    this.utilsService.scrollToTop();
+    this.document.getElementById(this.paginationTopElementId)?.focus();
+  }
+}

--- a/src/app/flows/fines/fines-acc/fines-acc-defendant-details/fines-acc-defendant-details-impositions-tab/fines-acc-defendant-details-impositions-tab.component.html
+++ b/src/app/flows/fines/fines-acc/fines-acc-defendant-details/fines-acc-defendant-details-impositions-tab/fines-acc-defendant-details-impositions-tab.component.html
@@ -1,3 +1,5 @@
+<div [id]="paginationTopElementId" class="govuk-visually-hidden" tabindex="-1"></div>
+
 <div class="govuk-grid-column-full">
   <h2 [class]="style.heading">Impositions</h2>
   <hr [class]="style.hr" />
@@ -178,6 +180,9 @@
       </opal-lib-moj-sortable-table>
     </opal-lib-custom-horizontal-scroll-pane>
     @if (filteredTableDataSignal().length > this.paginatedTableDataComputed().length) {
+      <span class="govuk-visually-hidden" role="status" aria-atomic="true">
+        {{ paginationStatusMessageComputed() }}
+      </span>
       <opal-lib-moj-pagination
         id="fines-acc-defendant-details-impositions-pagination"
         [currentPage]="currentPageSignal()"

--- a/src/app/flows/fines/fines-acc/fines-acc-defendant-details/fines-acc-defendant-details-impositions-tab/fines-acc-defendant-details-impositions-tab.component.spec.ts
+++ b/src/app/flows/fines/fines-acc/fines-acc-defendant-details/fines-acc-defendant-details-impositions-tab/fines-acc-defendant-details-impositions-tab.component.spec.ts
@@ -1,14 +1,28 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { OPAL_FINES_ACCOUNT_DEFENDANT_DETAILS_IMPOSITIONS_TAB_REF_DATA_MOCK } from '@services/fines/opal-fines-service/mocks/opal-fines-account-defendant-details-impositions.mock';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { UtilsService } from '@hmcts/opal-frontend-common/services/utils-service';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FinesAccDefendantDetailsImpositionsTabComponent } from './fines-acc-defendant-details-impositions-tab.component';
 
 describe('FinesAccDefendantDetailsImpositionsTabComponent', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let utilsService: any;
+
   beforeEach(async () => {
+    utilsService = {
+      convertToMonetaryString: vi.fn().mockImplementation((amount: number) => {
+        const numericAmount = Number(amount);
+        const formattedAmount = Math.abs(numericAmount).toFixed(2);
+
+        return numericAmount < 0 ? `-£${formattedAmount}` : `£${formattedAmount}`;
+      }),
+      scrollToTop: vi.fn().mockName('UtilsService.scrollToTop'),
+    };
+
     await TestBed.configureTestingModule({
       imports: [FinesAccDefendantDetailsImpositionsTabComponent],
-      providers: [provideRouter([])],
+      providers: [provideRouter([]), { provide: UtilsService, useValue: utilsService }],
     }).compileComponents();
   });
 
@@ -161,6 +175,33 @@ describe('FinesAccDefendantDetailsImpositionsTabComponent', () => {
     expect(component.paginatedTableDataComputed()).toHaveLength(8);
     expect(fixture.nativeElement.textContent).toContain('Major Creditor 23');
     expect(fixture.nativeElement.textContent).not.toContain('Central Funds');
+  });
+
+  it('should announce page changes, keep the active page marked current, and move focus to the top', () => {
+    const { component, fixture } = setupComponent();
+
+    const topAnchor = fixture.nativeElement.querySelector(
+      '#fines-acc-defendant-details-impositions-tab-top',
+    ) as HTMLDivElement | null;
+
+    expect(topAnchor).toBeTruthy();
+    if (!topAnchor) {
+      throw new Error('Top anchor not found');
+    }
+
+    const focusSpy = vi.spyOn(topAnchor, 'focus');
+
+    expect(fixture.nativeElement.querySelector('a[aria-current="page"]')?.textContent?.trim()).toBe('1');
+    expect(fixture.nativeElement.querySelector('[role="status"]')?.textContent).toContain('Page 1 loaded');
+
+    component.onPageChange(2);
+    fixture.detectChanges();
+
+    expect(component.currentPageSignal()).toBe(2);
+    expect(fixture.nativeElement.querySelector('a[aria-current="page"]')?.textContent?.trim()).toBe('2');
+    expect(fixture.nativeElement.querySelector('[role="status"]')?.textContent).toContain('Page 2 loaded');
+    expect(utilsService.scrollToTop).toHaveBeenCalled();
+    expect(focusSpy).toHaveBeenCalled();
   });
 
   it('should not render pagination when there are 25 or fewer imposition rows', () => {

--- a/src/app/flows/fines/fines-acc/fines-acc-defendant-details/fines-acc-defendant-details-impositions-tab/fines-acc-defendant-details-impositions-tab.component.ts
+++ b/src/app/flows/fines/fines-acc/fines-acc-defendant-details/fines-acc-defendant-details-impositions-tab/fines-acc-defendant-details-impositions-tab.component.ts
@@ -1,7 +1,6 @@
 import { NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, Input, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { AbstractSortableTablePaginationComponent } from '@hmcts/opal-frontend-common/components/abstract/abstract-sortable-table-pagination';
 import { CustomHorizontalScrollPaneComponent } from '@hmcts/opal-frontend-common/components/custom/custom-horizontal-scroll-pane';
 import { MojPaginationComponent } from '@hmcts/opal-frontend-common/components/moj/moj-pagination';
 import {
@@ -23,6 +22,7 @@ import { FINES_ACC_MINOR_CREDITOR_ROUTING_PATHS } from '../../routing/constants/
 import { FINES_ACC_MAJOR_CREDITOR_ROUTING_PATHS } from '../../routing/constants/fines-acc-major-creditor-routing-paths.constant';
 import { IFinesAccSummaryTabsContentStyles } from '../interfaces/fines-acc-summary-tabs-content-styles.interface';
 import { IAccountEnquiryImpositionTabTableRow } from '../interfaces/account-enquiry-imposition-tab-table-row.interface';
+import { AbstractSortableTablePaginationAccessibilityComponent } from '@app/flows/fines/components/abstract/abstract-sortable-table-pagination-accessibility/abstract-sortable-table-pagination-accessibility.component';
 
 @Component({
   selector: 'app-fines-acc-defendant-details-impositions-tab',
@@ -43,10 +43,11 @@ import { IAccountEnquiryImpositionTabTableRow } from '../interfaces/account-enqu
   templateUrl: './fines-acc-defendant-details-impositions-tab.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class FinesAccDefendantDetailsImpositionsTabComponent extends AbstractSortableTablePaginationComponent {
+export class FinesAccDefendantDetailsImpositionsTabComponent extends AbstractSortableTablePaginationAccessibilityComponent {
   protected readonly DATE_INPUT_FORMAT = 'yyyy-MM-dd';
   protected readonly DATE_OUTPUT_FORMAT = 'dd MMM yyyy';
   protected readonly zeroBalanceRowClass = 'govuk-light-grey-background-colour';
+  public readonly paginationTopElementId = 'fines-acc-defendant-details-impositions-tab-top';
 
   @Input({ required: true }) public set tabData(tabData: IOpalFinesAccountDefendantDetailsImpositionsTabRefData) {
     this.setTableData(tabData.impositions.map((imposition) => this.mapImpositionToTableRow(imposition)));

--- a/src/app/flows/fines/fines-draft/fines-draft-table-wrapper/fines-draft-table-wrapper.component.html
+++ b/src/app/flows/fines/fines-draft/fines-draft-table-wrapper/fines-draft-table-wrapper.component.html
@@ -1,3 +1,5 @@
+<div [id]="paginationTopElementId" class="govuk-visually-hidden" tabindex="-1"></div>
+
 <opal-lib-moj-sortable-table>
   <ng-container head>
     @if (activeTab === 'approved') {
@@ -140,6 +142,9 @@
   </ng-container>
 </opal-lib-moj-sortable-table>
 @if (filteredTableDataSignal().length > this.paginatedTableDataComputed().length) {
+  <span class="govuk-visually-hidden" role="status" aria-atomic="true">
+    {{ paginationStatusMessageComputed() }}
+  </span>
   <opal-lib-moj-pagination
     id="fines-draft-table-pagination"
     [currentPage]="currentPageSignal()"

--- a/src/app/flows/fines/fines-draft/fines-draft-table-wrapper/fines-draft-table-wrapper.component.spec.ts
+++ b/src/app/flows/fines/fines-draft/fines-draft-table-wrapper/fines-draft-table-wrapper.component.spec.ts
@@ -4,15 +4,40 @@ import { IFinesDraftTableWrapperTableData } from './interfaces/fines-draft-table
 import { IFinesDraftTableWrapperTableSort } from './interfaces/fines-draft-table-wrapper-table-sort.interface';
 import { FINES_DRAFT_TABLE_WRAPPER_SORT_DEFAULT } from './constants/fines-draft-table-wrapper-table-sort.constants';
 import { FINES_DRAFT_TABLE_WRAPPER_TABLE_DATA_MOCK } from './mocks/fines-draft-table-wrapper-table-data.mock';
+import { UtilsService } from '@hmcts/opal-frontend-common/services/utils-service';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const buildTableData = (count: number) =>
+  Array.from({ length: count }, (_, index) => {
+    const template =
+      FINES_DRAFT_TABLE_WRAPPER_TABLE_DATA_MOCK[index % FINES_DRAFT_TABLE_WRAPPER_TABLE_DATA_MOCK.length];
+    const suffix = index + 1;
+
+    return {
+      ...template,
+      Account: `${template.Account}-${suffix}`,
+      'Account id': 1000 + suffix,
+      'Defendant id': 2000 + suffix,
+      Defendant: `${template.Defendant} ${suffix}`,
+      CreatedDate: `${template.CreatedDate}`,
+      ChangedDate: `${template.ChangedDate}`,
+    };
+  });
 
 describe('FinesDraftTableWrapperComponent', () => {
   let component: FinesDraftTableWrapperComponent;
   let fixture: ComponentFixture<FinesDraftTableWrapperComponent>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let utilsService: any;
 
   beforeEach(async () => {
+    utilsService = {
+      scrollToTop: vi.fn().mockName('UtilsService.scrollToTop'),
+    };
+
     await TestBed.configureTestingModule({
       imports: [FinesDraftTableWrapperComponent],
+      providers: [{ provide: UtilsService, useValue: utilsService }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(FinesDraftTableWrapperComponent);
@@ -161,6 +186,37 @@ describe('FinesDraftTableWrapperComponent', () => {
 
     expect(accountCell?.textContent?.trim()).toBe(accountNumber);
     expect(accountLinks.some((anchor) => anchor.textContent?.trim() === accountNumber)).toBe(false);
+  });
+
+  it('should announce page changes, keep the active page marked current, and move focus to the top', () => {
+    const paginationFixture = TestBed.createComponent(FinesDraftTableWrapperComponent);
+    const paginationComponent = paginationFixture.componentInstance;
+    paginationFixture.componentRef.setInput('tableData', buildTableData(26));
+    paginationFixture.componentRef.setInput('existingSortState', FINES_DRAFT_TABLE_WRAPPER_SORT_DEFAULT);
+    paginationFixture.detectChanges();
+
+    const topAnchor = paginationFixture.nativeElement.querySelector(
+      '#fines-draft-table-wrapper-top',
+    ) as HTMLDivElement | null;
+
+    expect(topAnchor).toBeTruthy();
+    if (!topAnchor) {
+      throw new Error('Top anchor not found');
+    }
+
+    const focusSpy = vi.spyOn(topAnchor, 'focus');
+
+    expect(paginationFixture.nativeElement.querySelector('a[aria-current="page"]')?.textContent?.trim()).toBe('1');
+    expect(paginationFixture.nativeElement.querySelector('[role="status"]')?.textContent).toContain('Page 1 loaded');
+
+    paginationComponent.onPageChange(2);
+    paginationFixture.detectChanges();
+
+    expect(paginationComponent.currentPageSignal()).toBe(2);
+    expect(paginationFixture.nativeElement.querySelector('a[aria-current="page"]')?.textContent?.trim()).toBe('2');
+    expect(paginationFixture.nativeElement.querySelector('[role="status"]')?.textContent).toContain('Page 2 loaded');
+    expect(utilsService.scrollToTop).toHaveBeenCalled();
+    expect(focusSpy).toHaveBeenCalled();
   });
 
   it('should prevent default and emit accountClicked when onAccountClick is called with an event', () => {

--- a/src/app/flows/fines/fines-draft/fines-draft-table-wrapper/fines-draft-table-wrapper.component.ts
+++ b/src/app/flows/fines/fines-draft/fines-draft-table-wrapper/fines-draft-table-wrapper.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, signal, Output, computed } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, computed, signal, Output } from '@angular/core';
 import {
   MojSortableTableHeaderComponent,
   MojSortableTableRowDataComponent,
@@ -8,10 +8,10 @@ import {
 } from '@hmcts/opal-frontend-common/components/moj/moj-sortable-table';
 import { IFinesDraftTableWrapperTableData } from './interfaces/fines-draft-table-wrapper-table-data.interface';
 import { IFinesDraftTableWrapperTableSort } from './interfaces/fines-draft-table-wrapper-table-sort.interface';
-import { AbstractSortableTablePaginationComponent } from '@hmcts/opal-frontend-common/components/abstract/abstract-sortable-table-pagination';
 import { DaysAgoPipe } from '@hmcts/opal-frontend-common/pipes/days-ago';
 import { DateFormatPipe } from '@hmcts/opal-frontend-common/pipes/date-format';
 import { MojPaginationComponent } from '@hmcts/opal-frontend-common/components/moj/moj-pagination';
+import { AbstractSortableTablePaginationAccessibilityComponent } from '@app/flows/fines/components/abstract/abstract-sortable-table-pagination-accessibility/abstract-sortable-table-pagination-accessibility.component';
 
 @Component({
   selector: 'app-fines-draft-table-wrapper',
@@ -29,9 +29,10 @@ import { MojPaginationComponent } from '@hmcts/opal-frontend-common/components/m
   templateUrl: './fines-draft-table-wrapper.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class FinesDraftTableWrapperComponent extends AbstractSortableTablePaginationComponent {
+export class FinesDraftTableWrapperComponent extends AbstractSortableTablePaginationAccessibilityComponent {
   protected readonly DATE_INPUT_FORMAT = 'yyyy-MM-dd';
   protected readonly DATE_OUTPUT_FORMAT = 'dd MMM yyyy';
+  public readonly paginationTopElementId = 'fines-draft-table-wrapper-top';
 
   @Input({ required: true }) set tableData(tableData: IFinesDraftTableWrapperTableData[]) {
     this.setTableData(tableData);

--- a/src/app/flows/fines/fines-mac/fines-mac-offence-details/fines-mac-offence-details-review/fines-mac-offence-details-review-summary/fines-mac-offence-details-review-summary.component.html
+++ b/src/app/flows/fines/fines-mac/fines-mac-offence-details/fines-mac-offence-details-review/fines-mac-offence-details-review-summary/fines-mac-offence-details-review-summary.component.html
@@ -36,7 +36,7 @@
   </div>
   <hr />
   <div class="govuk-grid-row">
-    <ng-container *ngTemplateOutlet="offenceTemplate; context: { $implicit: true }"></ng-container>
+    <ng-container *ngTemplateOutlet="offenceTemplate"></ng-container>
   </div>
   <div class="govuk-grid-row">
     <ng-container *ngTemplateOutlet="returnToAccountDetails; context: { $implicit: false }"></ng-container>
@@ -69,7 +69,7 @@
         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-2" />
       </div>
 
-      <ng-container *ngTemplateOutlet="offenceTemplate; context: { $implicit: false }"></ng-container>
+      <ng-container *ngTemplateOutlet="offenceTemplate"></ng-container>
     }
     <div class="govuk-grid-column-full">
       <div class="border-bottom">
@@ -92,18 +92,14 @@
   </div>
 </ng-template>
 
-<ng-template #offenceTemplate let-emptyOffences>
+<ng-template #offenceTemplate>
   <div class="govuk-grid-column-full">
     <opal-lib-govuk-button
       buttonId="addAnOffence"
       buttonClasses="govuk-button--secondary"
       (buttonClickEvent)="addAnotherOffence()"
     >
-      @if (emptyOffences) {
-        Add an offence
-      } @else {
-        Add another offence
-      }
+      Add another offence
     </opal-lib-govuk-button>
   </div>
 </ng-template>

--- a/src/app/flows/fines/fines-mac/fines-mac-offence-details/fines-mac-offence-details-review/fines-mac-offence-details-review-summary/fines-mac-offence-details-review-summary.component.spec.ts
+++ b/src/app/flows/fines/fines-mac/fines-mac-offence-details/fines-mac-offence-details-review/fines-mac-offence-details-review-summary/fines-mac-offence-details-review-summary.component.spec.ts
@@ -98,32 +98,6 @@ describe('FinesMacOffenceDetailsReviewSummaryComponent', () => {
     expect(result).toBe(0);
   });
 
-  it('should show Add an offence when there are no offences', () => {
-    finesMacOffenceDetailsStore.setOffenceRemoved(true);
-
-    fixture = TestBed.createComponent(FinesMacOffenceDetailsReviewSummaryComponent);
-    component = fixture.componentInstance;
-
-    component.impositionRefData = OPAL_FINES_RESULTS_REF_DATA_MOCK;
-    component.majorCreditorRefData = OPAL_FINES_MAJOR_CREDITOR_REF_DATA_MOCK;
-    component.offencesImpositions = [];
-
-    finesMacStore.setFinesMacStore(structuredClone(FINES_MAC_STATE_MOCK));
-    mockUtilsService.getFormStatus.mockReturnValue(FINES_MAC_STATUS.PROVIDED);
-
-    fixture.detectChanges();
-
-    expect(fixture.nativeElement.textContent).toContain('Add an offence');
-    expect(fixture.nativeElement.textContent).not.toContain('Add another offence');
-  });
-
-  it('should show Add another offence when there is an existing offence', () => {
-    fixture.detectChanges();
-
-    expect(fixture.nativeElement.textContent).toContain('Add another offence');
-    expect(fixture.nativeElement.textContent).not.toContain('Add an offence');
-  });
-
   it('should ignore offences with a null offence id when building the hidden map', () => {
     component.offencesImpositions = [
       {

--- a/src/app/flows/fines/fines-mac/fines-mac-offence-details/fines-mac-offence-details-search-offences/fines-mac-offence-details-search-offences-results/fines-mac-offence-details-search-offences-results-table-wrapper/fines-mac-offence-details-search-offences-results-table-wrapper.component.html
+++ b/src/app/flows/fines/fines-mac/fines-mac-offence-details/fines-mac-offence-details-search-offences/fines-mac-offence-details-search-offences-results/fines-mac-offence-details-search-offences-results-table-wrapper/fines-mac-offence-details-search-offences-results-table-wrapper.component.html
@@ -1,3 +1,5 @@
+<div [id]="paginationTopElementId" class="govuk-visually-hidden" tabindex="-1"></div>
+
 <opal-lib-moj-sortable-table>
   <ng-container head>
     <th
@@ -89,6 +91,9 @@
 </opal-lib-moj-sortable-table>
 
 @if (displayTableDataSignal()!.length > this.paginatedTableDataComputed().length) {
+  <span class="govuk-visually-hidden" role="status" aria-atomic="true">
+    {{ paginationStatusMessageComputed() }}
+  </span>
   <opal-lib-moj-pagination
     id="fines-draft-table-pagination"
     [currentPage]="currentPageSignal()"

--- a/src/app/flows/fines/fines-mac/fines-mac-offence-details/fines-mac-offence-details-search-offences/fines-mac-offence-details-search-offences-results/fines-mac-offence-details-search-offences-results-table-wrapper/fines-mac-offence-details-search-offences-results-table-wrapper.component.spec.ts
+++ b/src/app/flows/fines/fines-mac/fines-mac-offence-details/fines-mac-offence-details-search-offences/fines-mac-offence-details-search-offences-results/fines-mac-offence-details-search-offences-results-table-wrapper/fines-mac-offence-details-search-offences-results-table-wrapper.component.spec.ts
@@ -2,7 +2,22 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FinesMacOffenceDetailsSearchOffencesResultsTableWrapperComponent } from './fines-mac-offence-details-search-offences-results-table-wrapper.component';
 import { UtilsService } from '@hmcts/opal-frontend-common/services/utils-service';
 import { FINES_MAC_OFFENCE_DETAILS_SEARCH_OFFENCES_RESULTS_TABLE_WRAPPER_LINK_DEFAULTS } from './constants/fines-mac-offence-details-search-offences-results-table-wrapper-link-defaults.constant';
+import { FINES_MAC_OFFENCE_DETAILS_SEARCH_OFFENCES_RESULTS_TABLE_WRAPPER_SORT_DEFAULT } from './constants/fines-mac-offence-details-search-offences-results-table-wrapper-sort-defaults.constant';
+import { FINES_MAC_OFFENCE_DETAILS_SEARCH_OFFENCES_RESULTS_TABLE_WRAPPER_TABLE_DATA_MOCK } from './mocks/fines-mac-offence-details-search-offences-results-table-wrapper-table-data.mock';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const buildTableData = (count: number) =>
+  Array.from({ length: count }, (_, index) => {
+    const template = FINES_MAC_OFFENCE_DETAILS_SEARCH_OFFENCES_RESULTS_TABLE_WRAPPER_TABLE_DATA_MOCK[index % 3];
+    const suffix = index + 1;
+
+    return {
+      ...template,
+      Code: `${template.Code}-${suffix}`,
+      'Short title': `${template['Short title']} ${suffix}`,
+      'Act and section': `${template['Act and section']} ${suffix}`,
+    };
+  });
 
 describe('FinesMacOffenceDetailsSearchOffencesResultsTableWrapperComponent', () => {
   let component: FinesMacOffenceDetailsSearchOffencesResultsTableWrapperComponent;
@@ -13,6 +28,7 @@ describe('FinesMacOffenceDetailsSearchOffencesResultsTableWrapperComponent', () 
   beforeEach(async () => {
     utilsService = {
       copyToClipboard: vi.fn().mockName('UtilsService.copyToClipboard'),
+      scrollToTop: vi.fn().mockName('UtilsService.scrollToTop'),
     };
 
     await TestBed.configureTestingModule({
@@ -147,5 +163,39 @@ describe('FinesMacOffenceDetailsSearchOffencesResultsTableWrapperComponent', () 
     vi.spyOn<any, any>(window, 'clearTimeout');
     component.ngOnDestroy();
     expect(window.clearTimeout).not.toHaveBeenCalled();
+  });
+
+  it('should announce page changes, keep the active page marked current, and move focus to the top', () => {
+    const paginationFixture = TestBed.createComponent(FinesMacOffenceDetailsSearchOffencesResultsTableWrapperComponent);
+    const paginationComponent = paginationFixture.componentInstance;
+    paginationFixture.componentRef.setInput('tableData', buildTableData(26));
+    paginationFixture.componentRef.setInput(
+      'existingSortState',
+      FINES_MAC_OFFENCE_DETAILS_SEARCH_OFFENCES_RESULTS_TABLE_WRAPPER_SORT_DEFAULT,
+    );
+    paginationFixture.detectChanges();
+
+    const topAnchor = paginationFixture.nativeElement.querySelector(
+      '#search-offences-results-top',
+    ) as HTMLDivElement | null;
+
+    expect(topAnchor).toBeTruthy();
+    if (!topAnchor) {
+      throw new Error('Top anchor not found');
+    }
+
+    const focusSpy = vi.spyOn(topAnchor, 'focus');
+
+    expect(paginationFixture.nativeElement.querySelector('a[aria-current="page"]')?.textContent?.trim()).toBe('1');
+    expect(paginationFixture.nativeElement.querySelector('[role="status"]')?.textContent).toContain('Page 1 loaded');
+
+    paginationComponent.onPageChange(2);
+    paginationFixture.detectChanges();
+
+    expect(paginationComponent.currentPageSignal()).toBe(2);
+    expect(paginationFixture.nativeElement.querySelector('a[aria-current="page"]')?.textContent?.trim()).toBe('2');
+    expect(paginationFixture.nativeElement.querySelector('[role="status"]')?.textContent).toContain('Page 2 loaded');
+    expect(utilsService.scrollToTop).toHaveBeenCalled();
+    expect(focusSpy).toHaveBeenCalled();
   });
 });

--- a/src/app/flows/fines/fines-mac/fines-mac-offence-details/fines-mac-offence-details-search-offences/fines-mac-offence-details-search-offences-results/fines-mac-offence-details-search-offences-results-table-wrapper/fines-mac-offence-details-search-offences-results-table-wrapper.component.ts
+++ b/src/app/flows/fines/fines-mac/fines-mac-offence-details/fines-mac-offence-details-search-offences/fines-mac-offence-details-search-offences-results/fines-mac-offence-details-search-offences-results-table-wrapper/fines-mac-offence-details-search-offences-results-table-wrapper.component.ts
@@ -1,5 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, Input, OnDestroy, signal, Signal } from '@angular/core';
-import { AbstractSortableTablePaginationComponent } from '@hmcts/opal-frontend-common/components/abstract/abstract-sortable-table-pagination';
+import { ChangeDetectionStrategy, Component, Input, OnDestroy, signal, Signal } from '@angular/core';
 import {
   MojSortableTableComponent,
   MojSortableTableHeaderComponent,
@@ -10,9 +9,9 @@ import {
 import { DateFormatPipe } from '@hmcts/opal-frontend-common/pipes/date-format';
 import { IFinesMacOffenceDetailsSearchOffencesResultsTableWrapperTableData } from './interfaces/fines-mac-offence-details-search-offences-results-table-wrapper-table-data.interface';
 import { IFinesMacOffenceDetailsSearchOffencesResultsTableWrapperTableSort } from './interfaces/fines-mac-offence-details-search-offences-results-table-wrapper-table-sort.interface';
-import { UtilsService } from '@hmcts/opal-frontend-common/services/utils-service';
 import { FINES_MAC_OFFENCE_DETAILS_SEARCH_OFFENCES_RESULTS_TABLE_WRAPPER_LINK_DEFAULTS } from './constants/fines-mac-offence-details-search-offences-results-table-wrapper-link-defaults.constant';
 import { MojPaginationComponent } from '@hmcts/opal-frontend-common/components/moj/moj-pagination';
+import { AbstractSortableTablePaginationAccessibilityComponent } from '@app/flows/fines/components/abstract/abstract-sortable-table-pagination-accessibility/abstract-sortable-table-pagination-accessibility.component';
 
 @Component({
   selector: 'app-fines-mac-offence-details-search-offences-results-table-wrapper',
@@ -30,14 +29,14 @@ import { MojPaginationComponent } from '@hmcts/opal-frontend-common/components/m
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FinesMacOffenceDetailsSearchOffencesResultsTableWrapperComponent
-  extends AbstractSortableTablePaginationComponent
+  extends AbstractSortableTablePaginationAccessibilityComponent
   implements OnDestroy
 {
   private copyCodeTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
-  protected readonly utilsService = inject(UtilsService);
   protected readonly DATE_INPUT_FORMAT = `yyyy-MM-dd'T'HH:mm:ss'Z'`;
   protected readonly DATE_OUTPUT_FORMAT = 'dd MMM yyyy';
+  public readonly paginationTopElementId = 'search-offences-results-top';
 
   public override displayTableDataSignal = signal<IFinesMacOffenceDetailsSearchOffencesResultsTableWrapperTableData[]>(
     [],

--- a/src/app/flows/fines/fines-sa/fines-sa-results/fines-sa-results-defendant-table-wrapper/fines-sa-results-defendant-table-wrapper.component.html
+++ b/src/app/flows/fines/fines-sa/fines-sa-results/fines-sa-results-defendant-table-wrapper/fines-sa-results-defendant-table-wrapper.component.html
@@ -1,3 +1,5 @@
+<div [id]="paginationTopElementId" class="govuk-visually-hidden" tabindex="-1"></div>
+
 <opal-lib-custom-horizontal-scroll-pane>
   <opal-lib-moj-sortable-table>
     <ng-container head>
@@ -223,6 +225,9 @@
   </opal-lib-moj-sortable-table>
 </opal-lib-custom-horizontal-scroll-pane>
 @if (filteredTableDataSignal().length > this.paginatedTableDataComputed().length) {
+  <span class="govuk-visually-hidden" role="status" aria-atomic="true">
+    {{ paginationStatusMessageComputed() }}
+  </span>
   <opal-lib-moj-pagination
     id="defendant-table-wrapper-pagination"
     [currentPage]="currentPageSignal()"

--- a/src/app/flows/fines/fines-sa/fines-sa-results/fines-sa-results-defendant-table-wrapper/fines-sa-results-defendant-table-wrapper.component.spec.ts
+++ b/src/app/flows/fines/fines-sa/fines-sa-results/fines-sa-results-defendant-table-wrapper/fines-sa-results-defendant-table-wrapper.component.spec.ts
@@ -3,15 +3,23 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FinesSaResultsDefendantTableWrapperComponent } from './fines-sa-results-defendant-table-wrapper.component';
 import { FINES_SA_RESULTS_DEFENDANT_TABLE_WRAPPER_TABLE_SORT_DEFAULT } from './constants/fines-sa-results-defendant-table-wrapper-table-sort-default.constant';
 import { GENERATE_FINES_SA_DEFENDANT_TABLE_WRAPPER_TABLE_DATA_MOCKS } from './mock/fines-sa-results-defendant-table-wrapper-table-data.mock';
+import { UtilsService } from '@hmcts/opal-frontend-common/services/utils-service';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('FinesSaResultsDefendantTableWrapperComponent', () => {
   let component: FinesSaResultsDefendantTableWrapperComponent;
   let fixture: ComponentFixture<FinesSaResultsDefendantTableWrapperComponent>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let utilsService: any;
 
   beforeEach(async () => {
+    utilsService = {
+      scrollToTop: vi.fn().mockName('UtilsService.scrollToTop'),
+    };
+
     await TestBed.configureTestingModule({
       imports: [FinesSaResultsDefendantTableWrapperComponent],
+      providers: [{ provide: UtilsService, useValue: utilsService }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(FinesSaResultsDefendantTableWrapperComponent);
@@ -106,5 +114,42 @@ describe('FinesSaResultsDefendantTableWrapperComponent', () => {
     expect(handlerSpy.mock.calls[0][0]).toBe(1);
     expect(handlerSpy.mock.calls[0][1]).toBe(event);
     expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('should announce page changes, keep the active page marked current, and move focus to the top', () => {
+    const paginationFixture = TestBed.createComponent(FinesSaResultsDefendantTableWrapperComponent);
+    const paginationComponent = paginationFixture.componentInstance;
+    paginationFixture.componentRef.setInput(
+      'tableData',
+      GENERATE_FINES_SA_DEFENDANT_TABLE_WRAPPER_TABLE_DATA_MOCKS(26),
+    );
+    paginationFixture.componentRef.setInput(
+      'existingSortState',
+      FINES_SA_RESULTS_DEFENDANT_TABLE_WRAPPER_TABLE_SORT_DEFAULT,
+    );
+    paginationFixture.detectChanges();
+
+    const topAnchor = paginationFixture.nativeElement.querySelector(
+      '#fines-sa-results-defendant-table-wrapper-top',
+    ) as HTMLDivElement | null;
+
+    expect(topAnchor).toBeTruthy();
+    if (!topAnchor) {
+      throw new Error('Top anchor not found');
+    }
+
+    const focusSpy = vi.spyOn(topAnchor, 'focus');
+
+    expect(paginationFixture.nativeElement.querySelector('a[aria-current="page"]')?.textContent?.trim()).toBe('1');
+    expect(paginationFixture.nativeElement.querySelector('[role="status"]')?.textContent).toContain('Page 1 loaded');
+
+    paginationComponent.onPageChange(2);
+    paginationFixture.detectChanges();
+
+    expect(paginationComponent.currentPageSignal()).toBe(2);
+    expect(paginationFixture.nativeElement.querySelector('a[aria-current="page"]')?.textContent?.trim()).toBe('2');
+    expect(paginationFixture.nativeElement.querySelector('[role="status"]')?.textContent).toContain('Page 2 loaded');
+    expect(utilsService.scrollToTop).toHaveBeenCalled();
+    expect(focusSpy).toHaveBeenCalled();
   });
 });

--- a/src/app/flows/fines/fines-sa/fines-sa-results/fines-sa-results-defendant-table-wrapper/fines-sa-results-defendant-table-wrapper.component.ts
+++ b/src/app/flows/fines/fines-sa/fines-sa-results/fines-sa-results-defendant-table-wrapper/fines-sa-results-defendant-table-wrapper.component.ts
@@ -8,7 +8,6 @@ import {
   MojSortableTableStatusComponent,
 } from '@hmcts/opal-frontend-common/components/moj/moj-sortable-table';
 import { DateFormatPipe } from '@hmcts/opal-frontend-common/pipes/date-format';
-import { AbstractSortableTablePaginationComponent } from '@hmcts/opal-frontend-common/components/abstract/abstract-sortable-table-pagination';
 import { IFinesSaResultsDefendantTableWrapperTableData } from './interfaces/fines-sa-results-defendant-table-wrapper-table-data.interface';
 import { IFinesSaResultsDefendantTableWrapperTableSort } from './interfaces/fines-sa-results-defendant-table-wrapper-table-sort.interface';
 import { NationalInsurancePipe } from '@hmcts/opal-frontend-common/pipes/national-insurance';
@@ -16,6 +15,7 @@ import { FINES_DEFAULT_VALUES } from '../../../constants/fines-default-values.co
 import { CustomHorizontalScrollPaneComponent } from '@hmcts/opal-frontend-common/components/custom/custom-horizontal-scroll-pane';
 import { MojPaginationComponent } from '@hmcts/opal-frontend-common/components/moj/moj-pagination';
 import { FinesNotProvidedComponent } from '../../../components/fines-not-provided/fines-not-provided.component';
+import { AbstractSortableTablePaginationAccessibilityComponent } from '@app/flows/fines/components/abstract/abstract-sortable-table-pagination-accessibility/abstract-sortable-table-pagination-accessibility.component';
 
 @Component({
   selector: 'app-fines-sa-results-defendant-table-wrapper',
@@ -35,9 +35,10 @@ import { FinesNotProvidedComponent } from '../../../components/fines-not-provide
   templateUrl: './fines-sa-results-defendant-table-wrapper.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class FinesSaResultsDefendantTableWrapperComponent extends AbstractSortableTablePaginationComponent {
+export class FinesSaResultsDefendantTableWrapperComponent extends AbstractSortableTablePaginationAccessibilityComponent {
   protected readonly DATE_INPUT_FORMAT = 'yyyy-MM-dd';
   protected readonly DATE_OUTPUT_FORMAT = 'dd MMM yyyy';
+  public readonly paginationTopElementId = 'fines-sa-results-defendant-table-wrapper-top';
 
   @Input({ required: true }) set tableData(tableData: IFinesSaResultsDefendantTableWrapperTableData[]) {
     this.setTableData(tableData);


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/PO-9047 

### Change description

- Use role="status" to voice page update when new pagination page is clicked.
- Move focus to the top of the page

### Testing done

- unit tests added
- manually interacted with pagination on the updated pages using voiceover:
`fines-mac-offence-details-search-offences`, `fines-draft-table-wrapper`, `fines-sa-results`, `fines-acc-defendant-details-impositions-tab`

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
