### PR TITLE
PO-9769 Changing display of submitted status on review account history screen

### DIFF
--- a/cypress/component/manualAccountCreation/FinesMacAccountDetails/FinesMacAccountDetails.cy.ts
+++ b/cypress/component/manualAccountCreation/FinesMacAccountDetails/FinesMacAccountDetails.cy.ts
@@ -569,7 +569,7 @@ describe('FinesMacAccountDetailsComponent', () => {
       });
       finesRejectedAccountMock.timeline_data.push({
         username: 'Timmy Test',
-        status: 'Submitted',
+        status: 'Resubmitted',
         status_date: '2023-07-07',
         reason_text: null,
       });
@@ -578,7 +578,7 @@ describe('FinesMacAccountDetailsComponent', () => {
 
       cy.get(L.timeLine).should('exist');
       const timelineEntries = [
-        { title: 'Submitted', author: 'by Timmy Test', date: '03 July 2023' },
+        { title: 'Created', author: 'by Timmy Test', date: '03 July 2023' },
         { title: 'Rejected', author: 'by Timmy Test', date: '05 July 2023' },
         { title: 'Submitted', author: 'by Timmy Test', date: '07 July 2023' },
       ];

--- a/cypress/component/manualAccountCreation/FinesMacReviewAccount/ViewAccountDeleted.cy.ts
+++ b/cypress/component/manualAccountCreation/FinesMacReviewAccount/ViewAccountDeleted.cy.ts
@@ -152,7 +152,7 @@ describe('FinesMacReviewAccountComponent - View Deleted Account', () => {
 
       cy.get(DOM_ELEMENTS.timelineAuthor).eq(0).should('contain.text', 'User.testone');
       cy.get(DOM_ELEMENTS.timelineDate).eq(0).should('contain.text', '02 January 2025');
-      cy.get(DOM_ELEMENTS.timeLineTitle).eq(0).should('contain.text', 'Resubmitted');
+      cy.get(DOM_ELEMENTS.timeLineTitle).eq(0).should('contain.text', 'Submitted');
       cy.get(DOM_ELEMENTS.timelineDescription).eq(0).should('contain.text', '');
 
       cy.get(DOM_ELEMENTS.timelineAuthor).eq(1).should('contain.text', 'Admin.testone');
@@ -162,7 +162,7 @@ describe('FinesMacReviewAccountComponent - View Deleted Account', () => {
 
       cy.get(DOM_ELEMENTS.timelineAuthor).eq(2).should('contain.text', 'User.testone');
       cy.get(DOM_ELEMENTS.timelineDate).eq(2).should('contain.text', '01 January 2025');
-      cy.get(DOM_ELEMENTS.timeLineTitle).eq(2).should('contain.text', 'Submitted');
+      cy.get(DOM_ELEMENTS.timeLineTitle).eq(2).should('contain.text', 'Created');
       cy.get(DOM_ELEMENTS.timelineDescription).eq(2).should('contain.text', '');
     },
   );

--- a/cypress/component/manualAccountCreation/FinesMacReviewAccount/ViewAccountRejected.cy.ts
+++ b/cypress/component/manualAccountCreation/FinesMacReviewAccount/ViewAccountRejected.cy.ts
@@ -160,7 +160,7 @@ describe('FinesMacReviewAccountComponent - View Rejected Account', () => {
 
       cy.get(DOM_ELEMENTS.timelineAuthor).eq(0).should('contain.text', 'User.testone');
       cy.get(DOM_ELEMENTS.timelineDate).eq(0).should('contain.text', '02 January 2025');
-      cy.get(DOM_ELEMENTS.timeLineTitle).eq(0).should('contain.text', 'Resubmitted');
+      cy.get(DOM_ELEMENTS.timeLineTitle).eq(0).should('contain.text', 'Submitted');
       cy.get(DOM_ELEMENTS.timelineDescription).eq(0).should('contain.text', '');
 
       cy.get(DOM_ELEMENTS.timelineAuthor).eq(1).should('contain.text', 'Admin.testone');
@@ -170,7 +170,7 @@ describe('FinesMacReviewAccountComponent - View Rejected Account', () => {
 
       cy.get(DOM_ELEMENTS.timelineAuthor).eq(2).should('contain.text', 'User.testone');
       cy.get(DOM_ELEMENTS.timelineDate).eq(2).should('contain.text', '01 January 2025');
-      cy.get(DOM_ELEMENTS.timeLineTitle).eq(2).should('contain.text', 'Submitted');
+      cy.get(DOM_ELEMENTS.timeLineTitle).eq(2).should('contain.text', 'Created');
       cy.get(DOM_ELEMENTS.timelineDescription).eq(2).should('contain.text', '');
     },
   );

--- a/cypress/component/manualAccountCreation/FinesMacReviewAccount/finesMacReviewAccount.cy.ts
+++ b/cypress/component/manualAccountCreation/FinesMacReviewAccount/finesMacReviewAccount.cy.ts
@@ -920,7 +920,7 @@ describe('FinesMacReviewAccountComponent', () => {
       cy.get(DOM_ELEMENTS.status).contains('In review').should('exist');
       cy.get(DOM_ELEMENTS.sectionHeading).contains('Review history').should('exist');
       cy.get(DOM_ELEMENTS.timeLine).should('exist');
-      cy.get(DOM_ELEMENTS.timeLineTitle).contains('Submitted').should('exist');
+      cy.get(DOM_ELEMENTS.timeLineTitle).contains('Created').should('exist');
       cy.get(DOM_ELEMENTS.timelineAuthor).contains('by Timmy Test').should('exist');
       cy.get(DOM_ELEMENTS.timelineDate).contains('03 July 2023').should('exist');
     },
@@ -952,7 +952,7 @@ describe('FinesMacReviewAccountComponent', () => {
       });
       finesAccountPayload.timeline_data.push({
         username: 'Timmy Test',
-        status: 'Submitted',
+        status: 'Resubmitted',
         status_date: '2023-07-07',
         reason_text: null,
       });
@@ -961,7 +961,7 @@ describe('FinesMacReviewAccountComponent', () => {
 
       cy.get(DOM_ELEMENTS.timeLine).should('exist');
       const timelineEntries = [
-        { title: 'Submitted', author: 'by Timmy Test', date: '03 July 2023' },
+        { title: 'Created', author: 'by Timmy Test', date: '03 July 2023' },
         { title: 'Rejected', author: 'by Timmy Test', date: '05 July 2023' },
         { title: 'Submitted', author: 'by Timmy Test', date: '07 July 2023' },
       ];

--- a/src/app/flows/fines/fines-mac/fines-mac-review-account/fines-mac-review-account-history/fines-mac-review-account-history.component.html
+++ b/src/app/flows/fines/fines-mac/fines-mac-review-account/fines-mac-review-account-history/fines-mac-review-account-history.component.html
@@ -12,7 +12,7 @@
 <opal-lib-moj-timeline>
   @for (timelineItem of timelineData; track $index) {
     <opal-lib-moj-timeline-item>
-      <span title>{{ timelineItem.status }}</span>
+      <span title>{{ getTimelineStatusLabel(timelineItem.status) }}</span>
       <span user>{{ timelineItem.username }}</span>
       <span date>{{ timelineItem.status_date | dateFormat: 'yyyy-MM-dd' : 'dd MMMM yyyy' }}</span>
       @if (timelineItem.reason_text) {

--- a/src/app/flows/fines/fines-mac/fines-mac-review-account/fines-mac-review-account-history/fines-mac-review-account-history.component.spec.ts
+++ b/src/app/flows/fines/fines-mac/fines-mac-review-account/fines-mac-review-account-history/fines-mac-review-account-history.component.spec.ts
@@ -14,10 +14,26 @@ describe('FinesMacReviewAccountHistoryComponent', () => {
 
     fixture = TestBed.createComponent(FinesMacReviewAccountHistoryComponent);
     component = fixture.componentInstance;
+    component.defendantName = 'John Smith';
+    component.accountStatus = 'Rejected';
+    component.timelineData = [];
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should display API timeline statuses using the review history labels', () => {
+    component.timelineData = [
+      { status: 'Submitted', username: 'User One', status_date: '2026-08-01', reason_text: null },
+      { status: 'Resubmitted', username: 'User Two', status_date: '2026-08-02', reason_text: null },
+      { status: 'Rejected', username: 'User Three', status_date: '2026-08-03', reason_text: 'Reason' },
+    ];
+
+    fixture.detectChanges();
+
+    const timelineTitles = Array.from<HTMLElement>(fixture.nativeElement.querySelectorAll('.moj-timeline__title'));
+    expect(timelineTitles.map(({ textContent }) => textContent?.trim())).toEqual(['Created', 'Submitted', 'Rejected']);
   });
 });

--- a/src/app/flows/fines/fines-mac/fines-mac-review-account/fines-mac-review-account-history/fines-mac-review-account-history.component.ts
+++ b/src/app/flows/fines/fines-mac/fines-mac-review-account/fines-mac-review-account-history/fines-mac-review-account-history.component.ts
@@ -7,6 +7,11 @@ import { IFinesMacAccountTimelineData } from '../../services/fines-mac-payload/i
 import { GovukTagComponent } from '@hmcts/opal-frontend-common/components/govuk/govuk-tag';
 import { DateFormatPipe } from '@hmcts/opal-frontend-common/pipes/date-format';
 
+const TIMELINE_STATUS_LABELS: Readonly<Record<string, string>> = {
+  Submitted: 'Created',
+  Resubmitted: 'Submitted',
+};
+
 @Component({
   selector: 'app-fines-mac-review-account-history',
   imports: [GovukTagComponent, MojTimelineComponent, MojTimelineItemComponent, DateFormatPipe],
@@ -17,4 +22,14 @@ export class FinesMacReviewAccountHistoryComponent {
   @Input({ required: true }) public defendantName!: string;
   @Input({ required: true }) public accountStatus!: string;
   @Input({ required: false }) public isRejected: boolean = false;
+
+  /**
+   * Returns the user-facing label for a draft account timeline status.
+   *
+   * @param status The status returned by the draft account API.
+   * @returns The status label to display in the review history.
+   */
+  public getTimelineStatusLabel(status: string): string {
+    return TIMELINE_STATUS_LABELS[status] ?? status;
+  }
 }


### PR DESCRIPTION
## Jira link

See [PO-9769](https://tools.hmcts.net/jira/browse/PO-9769)

## Change Description

### Change Overview
Updates the fines MAC review account history timeline so backend status values are displayed with the labels expected by the PO-9769 UAT journey.
The frontend now presents:

- Submitted as Created
- Resubmitted as Submitted

### Change Breakdown

- Added timeline display-label mapping in the fines MAC review account history component.
- Updated the review account history template to render mapped labels instead of raw status values.
- Added unit coverage for mapped and unmapped timeline statuses.
- Updated affected Cypress component test expectations and fixtures to reflect the new displayed timeline labels.

## Testing done

### Manual Testing
Manually verified expected behaviour.

### Automated Testing
Added unit test coverage for new functionality.
Updated relevant component tests to consider new wording.

### Security Vulnerability Assessment 

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
